### PR TITLE
fix: send SEARCH request to DAV root endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ const Files = {
     },
 
     async search(query) {
-        const endpoint = `/remote.php/dav/files/${CONFIG.user}/`;
+        const endpoint = `/remote.php/dav/`;
         const body = `
             <d:searchrequest xmlns:d="DAV:">
                 <d:basicsearch>

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -15349,7 +15349,7 @@ var Files = {
     return { path: filePath, status: "deleted" };
   },
   async search(query) {
-    const endpoint = `/remote.php/dav/files/${CONFIG.user}/`;
+    const endpoint = `/remote.php/dav/`;
     const body = `
             <d:searchrequest xmlns:d="DAV:">
                 <d:basicsearch>


### PR DESCRIPTION
fix: send SEARCH request to DAV root endpoint

The WebDAV SEARCH method must target /remote.php/dav/ per Nextcloud docs
(https://docs.nextcloud.com/server/stable/developer_manual/client_apis/WebDAV/search.html).
The search scope /files/{user} belongs in the XML body, not the request URL.

Previously sent to /remote.php/dav/files/{user}/ which returned 501 because
the SabreDAV SearchPlugin is only registered on the DAV root server.

Tested all 21 commands (notes, files, calendars, tasks, contacts) — full pass.

Signed-off-by: Kssimi Claw <claw@kssimi.fr>
Signed-off-by: Yassir EL KSSIMI <neras@kssimi.fr> https://kssimi.fr
Supervised-by: Human