### PR TITLE
Add support for task and calendar event descriptions in Nextcloud parser

### DIFF
--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -18013,12 +18013,14 @@ var CalDAV = {
           const calData = propstats[0]["d:prop"]["cal:calendar-data"];
           const uidMatch = calData.match(/UID:(.*)/);
           const summaryMatch = calData.match(/SUMMARY:(.*)/);
+	  const descriptionMatch = calData.match(/DESCRIPTION:(.*)/);
           const dtstartMatch = calData.match(/DTSTART(?:;.*)?:(.*)/);
           const dtendMatch = calData.match(/DTEND(?:;.*)?:(.*)/);
           const locationMatch = calData.match(/LOCATION:(.*)/);
           allEvents.push({
             uid: uidMatch ? uidMatch[1].trim() : "No UID",
             calendar: cal.displayname,
+	        description: descriptionMatch ? descriptionMatch[1].trim() : null,
             summary: summaryMatch ? summaryMatch[1].trim() : "No Title",
             start: dtstartMatch ? dtstartMatch[1].trim() : "Unknown",
             end: dtendMatch ? dtendMatch[1].trim() : null,
@@ -18075,6 +18077,7 @@ var CalDAV = {
           }
           const calData = propstats[0]["d:prop"]["cal:calendar-data"];
           const summaryMatch = calData.match(/SUMMARY:(.*)/);
+	      const descriptionMatch = calData.match(/DESCRIPTION:(.*)/);
           const statusMatch = calData.match(/STATUS:(.*)/);
           const uidMatch = calData.match(/UID:(.*)/);
           const dueMatch = calData.match(/DUE(?:;.*)?:(.*)/);
@@ -18083,6 +18086,7 @@ var CalDAV = {
             uid: uidMatch ? uidMatch[1].trim() : "No UID",
             calendar: cal.displayname,
             summary: summaryMatch ? summaryMatch[1].trim() : "No Title",
+	        description: descriptionMatch ? descriptionMatch[1].trim() : null,
             status: statusMatch ? statusMatch[1].trim() : "NEEDS-ACTION",
             due: dueMatch ? dueMatch[1].trim() : null,
             priority: priorityMatch ? parseInt(priorityMatch[1].trim(), 10) : null


### PR DESCRIPTION
This PR adds support for parsing and exposing DESCRIPTION fields from both CalDAV tasks (VTODO) and calendar events (VEVENT) in the Nextcloud integration.

Previously, the parser only extracted metadata such as title, UID, status, due date, and timestamps. As a result, important contextual information stored in task notes or event descriptions was silently discarded.

Descriptions are important because they often contain the actual actionable or semantic content associated with an item, for example:

task instructions
meeting agendas
URLs and dial-in information
notes and reminders
project context
checklists
automation metadata

Without descriptions, downstream LLM agents and automations only receive shallow metadata (SUMMARY) and lose critical context required for reasoning, prioritization, scheduling, and execution.