### PR TITLE
fix: handle vCard 3.0 group prefixes (item1.EMAIL, item1.TEL) in contact parser

### DIFF
--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -18557,7 +18557,7 @@ var Contacts = {
   _parseVCard(vcard) {
     const cleanValue = (val) => val ? val.replace(/&#13;/g, "").replace(/\r/g, "").trim() : null;
     const getField = (field) => {
-      const regex = new RegExp(`^${field}(?:;[^:]*)?:(.*)$`, "mi");
+      const regex = new RegExp(`^(?:[^.]+\\.)?${field}(?:;[^:]*)?:(.*)$`, "mi");
       const match = vcard.match(regex);
       return match ? cleanValue(match[1]) : null;
     };
@@ -18565,13 +18565,13 @@ var Contacts = {
     const fn = getField("FN");
     const n = getField("N");
     const phones = [];
-    const phoneRegex = /^TEL(?:;[^:]*)?:(.*)$/gmi;
+    const phoneRegex = /^(?:[^.]+\.)?TEL(?:;[^:]*)?:(.*)$/gmi;
     let phoneMatch;
     while ((phoneMatch = phoneRegex.exec(vcard)) !== null) {
       phones.push(cleanValue(phoneMatch[1]));
     }
     const emails = [];
-    const emailRegex = /^EMAIL(?:;[^:]*)?:(.*)$/gmi;
+    const emailRegex = /^(?:[^.]+\.)?EMAIL(?:;[^:]*)?:(.*)$/gmi;
     let emailMatch;
     while ((emailMatch = emailRegex.exec(vcard)) !== null) {
       emails.push(cleanValue(emailMatch[1]));
@@ -18687,10 +18687,10 @@ FN:${fullName}
     return { uid, status: "created", addressBook: ab.displayname };
   },
   _updateVCardField(vcard, field, value) {
-    const regex = new RegExp(`^${field}(?:;[^:]*)?:.*$`, "mi");
+    const regex = new RegExp(`^((?:[^.]+\\.)?${field}(?:;[^:]*)?:).*$`, "mi");
     const newLine = `${field}:${value}`;
     if (regex.test(vcard)) {
-      return vcard.replace(regex, newLine);
+      return vcard.replace(regex, (match, prefix) => `${prefix}${value}`);
     } else {
       return vcard.replace("END:VCARD", `${newLine}
 END:VCARD`);


### PR DESCRIPTION
The vCard 3.0 spec allows group prefixes like 'item1.' before property names when multiple instances of the same property type exist. The regexes in _parseVCard and _updateVCardField only matched bare property names, so contacts with grouped properties (e.g. item1.EMAIL;type=INTERNET) were silently skipped.

This adds optional (?:item\d+\.)? prefix to all vCard property regexes.