### PR TITLE
Fix OpenClaw skill config key stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,15 @@ A Node.js CLI tool for interacting with Nextcloud services including notes, file
 
 ### OpenClaw
 
-Install the skill with its canonical name so the skill metadata, configuration,
-and runtime credential injection all use the same stable key:
+Install the skill from the repository:
 
 ```bash
-openclaw skills install \
-  --as openclaw-nextcloud \
-  git:https://github.com/keithvassallomt/openclaw-nextcloud.git
+openclaw skills install git:keithvassallomt/openclaw-nextcloud@main
 ```
 
 The skill also declares `metadata.openclaw.skillKey: openclaw-nextcloud`.
-This keeps the configuration key stable if an installer assigns a different
-directory or source slug.
+This keeps the configuration and runtime credential-injection key stable
+regardless of the source slug or install directory.
 
 ### Source checkout
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ A Node.js CLI tool for interacting with Nextcloud services including notes, file
 
 ## Installation
 
+### OpenClaw
+
+Install the skill with its canonical name so the skill metadata, configuration,
+and runtime credential injection all use the same stable key:
+
+```bash
+openclaw skills install \
+  --as openclaw-nextcloud \
+  git:https://github.com/keithvassallomt/openclaw-nextcloud.git
+```
+
+The skill also declares `metadata.openclaw.skillKey: openclaw-nextcloud`.
+This keeps the configuration key stable if an installer assigns a different
+directory or source slug.
+
+### Source checkout
+
 ```bash
 git clone https://github.com/keithvassallomt/openclaw-nextcloud.git
 cd openclaw-nextcloud
@@ -55,7 +72,27 @@ nix shell .#default --command npm run build
 ```
 
 ## Configuration
-Store these values in environment variables, or openclawd.json, or use a .env file.
+
+For an OpenClaw installation, configure the non-secret values under the
+canonical skill key:
+
+```bash
+openclaw config set \
+  skills.entries.openclaw-nextcloud.env.NEXTCLOUD_URL \
+  https://your-nextcloud-instance.com
+openclaw config set \
+  skills.entries.openclaw-nextcloud.env.NEXTCLOUD_USER \
+  your_username
+```
+
+Save the app password through **Control UI → Skills → openclaw-nextcloud →
+Save key**. OpenClaw stores it as the skill's `apiKey` and injects it as
+`NEXTCLOUD_TOKEN` only for agent runs. Prefer a supported OpenClaw SecretRef
+when managing credentials outside the Control UI. Do not put the app password
+in prompts, shell history, examples, or logs.
+
+For direct CLI use outside OpenClaw, provide the same values as environment
+variables:
 
 ```env
 NEXTCLOUD_URL=https://your-nextcloud-instance.com
@@ -67,7 +104,27 @@ NEXTCLOUD_TOKEN=your_app_password
 1. Log into your Nextcloud instance
 2. Go to Settings → Security
 3. Under "Devices & sessions", enter a name for the app and click "Create new app password"
-4. Copy the generated password to your `.env` file
+4. Save the generated password as described above
+
+### Verify runtime injection
+
+First confirm that OpenClaw considers the skill ready:
+
+```bash
+openclaw skills info openclaw-nextcloud
+```
+
+Then perform a read-only agent check. The check should inspect presence only,
+must not read configuration files, and must never print credential values:
+
+```bash
+openclaw agent --agent main --message \
+  "Without reading config files or printing values, report whether NEXTCLOUD_URL, NEXTCLOUD_USER, and NEXTCLOUD_TOKEN are present. If all are present, use the Nextcloud skill to list calendars only. Make no changes."
+```
+
+If readiness succeeds but the agent reports missing variables, verify that the
+installed skill resolves to `skillKey: openclaw-nextcloud` and that the config
+entry uses `skills.entries.openclaw-nextcloud`.
 
 ## Usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -38,7 +38,7 @@ This skill provides integration with a Nextcloud instance. It supports access to
 
 ## Requirements
 
-- **Node.js 20+** on PATH (`node scripts/nextcloud.js`).
+- **Node.js 20+** on PATH (`node {baseDir}/scripts/nextcloud.js`).
 - **Network egress** to `NEXTCLOUD_URL` only — the skill makes no other outbound calls.
 - **Environment variables** (see Configuration below). All three are required at runtime; without them the script exits with a clear error before making any request.
 
@@ -114,10 +114,11 @@ Notes, file contents, calendar event descriptions, contact notes, and similar fi
 
 ## Usage
 
-Run the skill via the bundled script.
+Run the skill via the bundled script. Always use `{baseDir}` so the command
+works regardless of the agent workspace or the skill's install alias.
 
 ```bash
-node scripts/nextcloud.js <command> <subcommand> [options]
+node {baseDir}/scripts/nextcloud.js <command> <subcommand> [options]
 ```
 
 ## Commands

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,6 +6,7 @@ allowed-tools: Bash Read
 metadata:
   openclaw:
     version: 0.3.0
+    skillKey: openclaw-nextcloud
     requires:
       env:
         - NEXTCLOUD_URL

--- a/SKILL.md
+++ b/SKILL.md
@@ -38,7 +38,8 @@ This skill provides integration with a Nextcloud instance. It supports access to
 
 ## Requirements
 
-- **Node.js 20+** on PATH (`node {baseDir}/scripts/nextcloud.js`).
+- **Node.js 20+** on PATH (`node scripts/nextcloud.js` in Claude Code or a
+  source checkout; `node {baseDir}/scripts/nextcloud.js` in OpenClaw).
 - **Network egress** to `NEXTCLOUD_URL` only — the skill makes no other outbound calls.
 - **Environment variables** (see Configuration below). All three are required at runtime; without them the script exits with a clear error before making any request.
 
@@ -114,8 +115,17 @@ Notes, file contents, calendar event descriptions, contact notes, and similar fi
 
 ## Usage
 
-Run the skill via the bundled script. Always use `{baseDir}` so the command
-works regardless of the agent workspace or the skill's install alias.
+Run the bundled script with a path appropriate for the host.
+
+Claude Code and direct source checkouts resolve the relative path from the
+skill directory:
+
+```bash
+node scripts/nextcloud.js <command> <subcommand> [options]
+```
+
+OpenClaw commands may run from another workspace, so use its `{baseDir}`
+placeholder:
 
 ```bash
 node {baseDir}/scripts/nextcloud.js <command> <subcommand> [options]


### PR DESCRIPTION
## What changed

- declare `metadata.openclaw.skillKey: openclaw-nextcloud`
- document `git:keithvassallomt/openclaw-nextcloud@main` installation
- distinguish Claude Code’s relative script path from OpenClaw’s `{baseDir}` path
- document safe credential storage and a presence-only runtime verification flow
- keep package and skill versions unchanged

## Why

OpenClaw can install a skill under a directory or source alias that differs from the skill name. Without an explicit `skillKey`, readiness checks may find one configuration entry while runtime environment injection looks up another.

## Impact

OpenClaw resolves one stable configuration key, while Claude Code and direct source checkout usage remain unchanged.

## Validation

- rebased onto current upstream `main`
- reproduced and verified the OpenClaw configuration fix on the live installation
- completed a read-only calendar listing
- `git diff --check`
