### PR TITLE
ci: verify the committed bundle matches index.js

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -1,0 +1,46 @@
+name: bundle
+
+# scripts/nextcloud.js is a build artifact, but it is also the file end users
+# and agents actually run — the skill's no-install promise depends on it being
+# committed. That makes it possible to change one half of the pair and ship a
+# bundle that no longer matches its source, in either direction. This job
+# rebuilds from index.js and fails if the committed bundle differs.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  verify:
+    name: committed bundle matches index.js
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code --stat scripts/nextcloud.js; then
+            echo
+            echo "::error file=scripts/nextcloud.js::Committed bundle does not match a fresh build of index.js"
+            echo "Rebuilding index.js produced a different scripts/nextcloud.js."
+            echo
+            echo "This usually means a change landed in only one of the two files."
+            echo "Fix it by running the build locally and committing both together:"
+            echo
+            echo "    npm install && npm run build"
+            echo "    git add index.js scripts/nextcloud.js"
+            echo
+            echo "Full diff between the committed bundle and the fresh build:"
+            git --no-pager diff scripts/nextcloud.js
+            exit 1
+          fi

--- a/index.js
+++ b/index.js
@@ -1139,7 +1139,7 @@ const Contacts = {
         const cleanValue = (val) => val ? val.replace(/&#13;/g, '').replace(/\r/g, '').trim() : null;
 
         const getField = (field) => {
-            const regex = new RegExp(`^${field}(?:;[^:]*)?:(.*)$`, 'mi');
+            const regex = new RegExp(`^(?:[^.]+\\.)?${field}(?:;[^:]*)?:(.*)$`, 'mi');
             const match = vcard.match(regex);
             return match ? cleanValue(match[1]) : null;
         };
@@ -1150,7 +1150,7 @@ const Contacts = {
 
         // Parse phone numbers (can have multiple)
         const phones = [];
-        const phoneRegex = /^TEL(?:;[^:]*)?:(.*)$/gmi;
+        const phoneRegex = /^(?:[^.]+\.)?TEL(?:;[^:]*)?:(.*)$/gmi;
         let phoneMatch;
         while ((phoneMatch = phoneRegex.exec(vcard)) !== null) {
             phones.push(cleanValue(phoneMatch[1]));
@@ -1158,7 +1158,7 @@ const Contacts = {
 
         // Parse emails (can have multiple)
         const emails = [];
-        const emailRegex = /^EMAIL(?:;[^:]*)?:(.*)$/gmi;
+        const emailRegex = /^(?:[^.]+\.)?EMAIL(?:;[^:]*)?:(.*)$/gmi;
         let emailMatch;
         while ((emailMatch = emailRegex.exec(vcard)) !== null) {
             emails.push(cleanValue(emailMatch[1]));
@@ -1281,10 +1281,10 @@ const Contacts = {
     },
 
     _updateVCardField(vcard, field, value) {
-        const regex = new RegExp(`^${field}(?:;[^:]*)?:.*$`, 'mi');
+        const regex = new RegExp(`^((?:[^.]+\\.)?${field}(?:;[^:]*)?:).*$`, 'mi');
         const newLine = `${field}:${value}`;
         if (regex.test(vcard)) {
-            return vcard.replace(regex, newLine);
+            return vcard.replace(regex, (match, prefix) => `${prefix}${value}`);
         } else {
             return vcard.replace('END:VCARD', `${newLine}\nEND:VCARD`);
         }


### PR DESCRIPTION
`scripts/nextcloud.js` is generated from `index.js`, but it is also the file end users and agents actually run — the no-install promise depends on it being committed. Nothing enforced that the two stay in step, and it has now drifted three times:

| PR | What landed | Outcome |
|---|---|---|
| #6 | `index.js` only | Caught after merge, rebuilt in f2fa6aa |
| #7 | bundle only | Caught in review, before merge |
| #9 | bundle only | Merged as-is — still drifted on `main` until this PR |

The pattern is that it slips through on the changes that look too small to need scrutiny. #9 was a five-line regex fix.

## What this adds

A GitHub Actions job that runs `npm run build` and fails if `scripts/nextcloud.js` comes out different from what's committed. A half-landed change now goes red on the PR instead of depending on someone remembering to check by hand.

This also makes the README's **"Auditing the bundle"** section something the repo guarantees on every commit, rather than something we ask users to verify for themselves.

## Why it also touches index.js

The new job would have failed on `main` the moment it landed. #9's group-prefix fix only ever existed in the bundle, so the next `npm run build` by anyone would have silently reverted it — the committed bundle was correct, but the source was stale.

`index.js` now carries the same four changes the merged bundle already had:

- group prefix in `_parseVCard`'s `getField`, `phoneRegex` and `emailRegex`
- group-preserving capture in `_updateVCardField`

Ported verbatim from the merged bundle rather than adopting the tightened form proposed in #10 (`[A-Za-z0-9-]+` plus `\r\n` in the parameter class), to keep this a parity restore. #10 will need a trivial rebase — those hunks should drop out cleanly, and its tightening remains its own contribution.

## Verification

- `npm run build` is byte-identical to the committed bundle (`git diff --exit-code` clean)
- Deliberately drifted the source and confirmed the job fails; reverted and confirmed it passes
- Grouped vCards (`item1.EMAIL;TYPE=work:`, `item2.TEL:`) parse correctly, and `contacts edit --email` rewrites the value while preserving both the `item1.` group and the `TYPE=work` parameter
- Workflow YAML parses; `npm ci` succeeds against the current lockfile despite its stale root version

Worth landing before #10 and #11, so both get checked on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)