### PR TITLE
fix(deck): send Content-Type on DELETE requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1712,7 +1712,7 @@ const Deck = {
 
     async deleteBoard(boardId) {
         if (!boardId) throw new Error('Board ID is required for deletion.');
-        await request(`${this._base}/boards/${boardId}`, { method: 'DELETE', headers: this._headers });
+        await request(`${this._base}/boards/${boardId}`, { method: 'DELETE', headers: this._jsonHeaders });
         return { success: true, id: boardId };
     },
 
@@ -1761,7 +1761,7 @@ const Deck = {
 
     async deleteStack(boardId, stackId) {
         if (!boardId || !stackId) throw new Error('Board ID and Stack ID are required for deletion.');
-        await request(`${this._base}/boards/${boardId}/stacks/${stackId}`, { method: 'DELETE', headers: this._headers });
+        await request(`${this._base}/boards/${boardId}/stacks/${stackId}`, { method: 'DELETE', headers: this._jsonHeaders });
         return { success: true, id: stackId };
     },
 
@@ -1818,7 +1818,7 @@ const Deck = {
 
     async deleteCard(boardId, stackId, cardId) {
         if (!boardId || !stackId || !cardId) throw new Error('Board ID, Stack ID and Card ID are required for deletion.');
-        await request(`${this._base}/boards/${boardId}/stacks/${stackId}/cards/${cardId}`, { method: 'DELETE', headers: this._headers });
+        await request(`${this._base}/boards/${boardId}/stacks/${stackId}/cards/${cardId}`, { method: 'DELETE', headers: this._jsonHeaders });
         return { success: true, id: cardId };
     },
 
@@ -1898,7 +1898,7 @@ const Deck = {
 
     async deleteLabel(boardId, labelId) {
         if (!boardId || !labelId) throw new Error('Board ID and Label ID are required for deletion.');
-        await request(`${this._base}/boards/${boardId}/labels/${labelId}`, { method: 'DELETE', headers: this._headers });
+        await request(`${this._base}/boards/${boardId}/labels/${labelId}`, { method: 'DELETE', headers: this._jsonHeaders });
         return { success: true, id: labelId };
     },
 

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -19035,7 +19035,7 @@ var Deck = {
   },
   async deleteBoard(boardId) {
     if (!boardId) throw new Error("Board ID is required for deletion.");
-    await request(`${this._base}/boards/${boardId}`, { method: "DELETE", headers: this._headers });
+    await request(`${this._base}/boards/${boardId}`, { method: "DELETE", headers: this._jsonHeaders });
     return { success: true, id: boardId };
   },
   // --- Stacks (columns) ---
@@ -19080,7 +19080,7 @@ var Deck = {
   },
   async deleteStack(boardId, stackId) {
     if (!boardId || !stackId) throw new Error("Board ID and Stack ID are required for deletion.");
-    await request(`${this._base}/boards/${boardId}/stacks/${stackId}`, { method: "DELETE", headers: this._headers });
+    await request(`${this._base}/boards/${boardId}/stacks/${stackId}`, { method: "DELETE", headers: this._jsonHeaders });
     return { success: true, id: stackId };
   },
   // --- Cards ---
@@ -19131,7 +19131,7 @@ var Deck = {
   },
   async deleteCard(boardId, stackId, cardId) {
     if (!boardId || !stackId || !cardId) throw new Error("Board ID, Stack ID and Card ID are required for deletion.");
-    await request(`${this._base}/boards/${boardId}/stacks/${stackId}/cards/${cardId}`, { method: "DELETE", headers: this._headers });
+    await request(`${this._base}/boards/${boardId}/stacks/${stackId}/cards/${cardId}`, { method: "DELETE", headers: this._jsonHeaders });
     return { success: true, id: cardId };
   },
   async moveCard(boardId, stackId, cardId, toStackId, order = 999) {
@@ -19199,7 +19199,7 @@ var Deck = {
   },
   async deleteLabel(boardId, labelId) {
     if (!boardId || !labelId) throw new Error("Board ID and Label ID are required for deletion.");
-    await request(`${this._base}/boards/${boardId}/labels/${labelId}`, { method: "DELETE", headers: this._headers });
+    await request(`${this._base}/boards/${boardId}/labels/${labelId}`, { method: "DELETE", headers: this._jsonHeaders });
     return { success: true, id: labelId };
   },
   // --- Comments (OCS Deck API) ---

--- a/test/safety-features.mjs
+++ b/test/safety-features.mjs
@@ -19,6 +19,7 @@ const server = http.createServer(async (req, res) => {
   requests.push({
     method: req.method,
     url: req.url,
+    headers: req.headers,
     body
   });
 
@@ -263,6 +264,49 @@ record(
     requests.length === before,
   { result }
 );
+
+// Nextcloud's Deck API answers 403 to a DELETE that arrives without a JSON
+// content type, so these four requests must carry the same headers as the
+// POST/PUT methods beside them rather than the bare listing headers.
+const deckDeletes = [
+  {
+    name: 'boards delete',
+    args: ['boards', 'delete', '--board', '1', '--confirm', 'boards:delete'],
+    url: '/index.php/apps/deck/api/v1.1/boards/1'
+  },
+  {
+    name: 'stacks delete',
+    args: ['stacks', 'delete', '--board', '1', '--stack', '2',
+           '--confirm', 'stacks:delete'],
+    url: '/index.php/apps/deck/api/v1.1/boards/1/stacks/2'
+  },
+  {
+    name: 'cards delete',
+    args: ['cards', 'delete', '--board', '1', '--stack', '2', '--card', '3',
+           '--confirm', 'cards:delete'],
+    url: '/index.php/apps/deck/api/v1.1/boards/1/stacks/2/cards/3'
+  },
+  {
+    name: 'labels delete',
+    args: ['labels', 'delete', '--board', '1', '--label', '4',
+           '--confirm', 'labels:delete'],
+    url: '/index.php/apps/deck/api/v1.1/boards/1/labels/4'
+  }
+];
+
+for (const deckDelete of deckDeletes) {
+  before = requests.length;
+  result = await run(deckDelete.args);
+  const sent = requests.slice(before).find(entry => entry.method === 'DELETE');
+  record(
+    `${deckDelete.name} sends a JSON content type`,
+    result.code === 0 &&
+      sent?.url === deckDelete.url &&
+      sent?.headers['content-type'] === 'application/json' &&
+      sent?.headers['ocs-apirequest'] === 'true',
+    { request: sent, result }
+  );
+}
 } finally {
   rmSync(tempDir, { recursive: true, force: true });
   await new Promise(resolveClose => server.close(resolveClose));


### PR DESCRIPTION
On Nextcloud 34.0.2, Deck DELETE endpoints return `403 Forbidden` unless the request includes `Content-Type: application/json`.

The four Deck DELETE methods (`deleteBoard`, `deleteStack`, `deleteCard`, `deleteLabel`) were using `this._headers`, which only sets `OCS-APIRequest` and `Accept`. Switching them to `this._jsonHeaders` adds `Content-Type: application/json`, matching the POST/PUT methods and resolving the 403.

`scripts/nextcloud.js` was rebuilt with `npm run build` after the source change.

This patch has been used successfully against Nextcloud 34.0.2; no fresh live DELETE test was run for this PR to avoid mutating production board data.
