### PR TITLE
feat(calendar): add confirmed attendee support to event creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,13 @@ variables:
 NEXTCLOUD_URL=https://your-nextcloud-instance.com
 NEXTCLOUD_USER=your_username
 NEXTCLOUD_TOKEN=your_app_password
+NEXTCLOUD_EMAIL=you@example.com   # optional, see below
 ```
+
+`NEXTCLOUD_EMAIL` is optional. When set, `calendar create` marks the account as
+the event's organiser and as an attendee who has already accepted, so clients
+show the event as confirmed rather than as an invitation awaiting a reply. Left
+unset, events are written exactly as they were before the option existed.
 
 **Generating an App Password:**
 1. Log into your Nextcloud instance
@@ -439,7 +445,7 @@ This skill executes a bundled JavaScript file (`scripts/nextcloud.js`) on your m
 **What it can access**
 
 - The Nextcloud instance at `NEXTCLOUD_URL` — no other endpoints. There is no telemetry, no analytics, no auto-update, no third-party calls. You can confirm this by `grep -E 'fetch\(|http[s]?://' scripts/nextcloud.js`; every URL is built from `CONFIG.url` (i.e. `NEXTCLOUD_URL`) or relative API paths.
-- The environment variables `NEXTCLOUD_URL`, `NEXTCLOUD_USER`, `NEXTCLOUD_TOKEN`. No other env vars are read.
+- The environment variables `NEXTCLOUD_URL`, `NEXTCLOUD_USER`, `NEXTCLOUD_TOKEN`, and two optional ones: `NEXTCLOUD_EMAIL` (an address written into events you create, see [Configuration](#configuration)) and `OPENCLAW_ALLOW_HTTP` (the plaintext-HTTP opt-out). No other env vars are read; `grep -o 'process\.env\.[A-Z_]*' index.js` lists them.
 - No filesystem access beyond the Node module loader and the standard `fs` for reading inputs you pass it.
 
 **Credentials**

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openclaw-nextcloud
 description: Manage Notes, Tasks, Calendar, Files, Contacts, and Deck Kanban boards in your Nextcloud instance via CalDAV, WebDAV, Notes, and Deck APIs. Use for creating notes, managing todos and calendar events, uploading/downloading files, managing contacts, and organizing Kanban boards, stacks, and cards.
-compatibility: Requires Node.js 24+ and a Nextcloud app password (NEXTCLOUD_TOKEN) granting full account-scope access. Reads NEXTCLOUD_URL, NEXTCLOUD_USER, NEXTCLOUD_TOKEN. HTTPS-only egress to NEXTCLOUD_URL. Performs destructive, non-transactional writes (delete/edit/share); see Safety section in body.
+compatibility: Requires Node.js 24+ and a Nextcloud app password (NEXTCLOUD_TOKEN) granting full account-scope access. Reads NEXTCLOUD_URL, NEXTCLOUD_USER, NEXTCLOUD_TOKEN, and optionally NEXTCLOUD_EMAIL. HTTPS-only egress to NEXTCLOUD_URL. Performs destructive, non-transactional writes (delete/edit/share); see Safety section in body.
 allowed-tools: Bash Read
 metadata:
   openclaw:
@@ -25,6 +25,9 @@ metadata:
       - name: NEXTCLOUD_TOKEN
         required: true
         description: Sensitive. Nextcloud app password granting full account-scope access. Use an app password from Settings → Security, not the account password.
+      - name: NEXTCLOUD_EMAIL
+        required: false
+        description: Optional. Email address of the account. When set, created calendar events name it as the organiser and as an accepted attendee, so clients show them as confirmed rather than awaiting an RSVP.
     homepage: https://github.com/keithvassallomt/openclaw-nextcloud
   credential-scope: nextcloud-account-full
   network-egress: ${NEXTCLOUD_URL}
@@ -41,7 +44,7 @@ This skill provides integration with a Nextcloud instance. It supports access to
 - **Node.js 24+** on PATH (`node scripts/nextcloud.js` in Claude Code or a
   source checkout; `node {baseDir}/scripts/nextcloud.js` in OpenClaw).
 - **Network egress** to `NEXTCLOUD_URL` only — the skill makes no other outbound calls.
-- **Environment variables** (see Configuration below). All three are required at runtime; without them the script exits with a clear error before making any request.
+- **Environment variables** (see Configuration below). The first three are required at runtime; without them the script exits with a clear error before making any request. `NEXTCLOUD_EMAIL` is optional.
 
 ## Configuration
 
@@ -50,6 +53,7 @@ The skill requires the following environment variables:
 - `NEXTCLOUD_URL`: The base URL of your Nextcloud instance (e.g., `https://cloud.example.com`).
 - `NEXTCLOUD_USER`: Your Nextcloud username.
 - `NEXTCLOUD_TOKEN`: **Sensitive.** Use a Nextcloud **app password** (Settings → Security → "Devices & sessions"), not your account password. App passwords can be revoked from the Nextcloud UI without changing your main credentials, and limit blast radius if leaked.
+- `NEXTCLOUD_EMAIL`: *Optional.* The account's email address. When set, `calendar create` adds `STATUS:CONFIRMED` plus `ORGANIZER` and `ATTENDEE` lines naming this address as having accepted, so calendar clients show the event as confirmed instead of as a pending invitation. Unset, events are created exactly as before. It must be a plain address such as `user@example.com`; anything else is rejected.
 
 `NEXTCLOUD_URL` must use `https://`. The script refuses to run over plain HTTP (except `localhost`/`127.0.0.1`/`[::1]`); set `OPENCLAW_ALLOW_HTTP=1` to override (not recommended outside isolated dev).
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ import crypto from 'node:crypto';
 const CONFIG = {
     url: process.env.NEXTCLOUD_URL,
     user: process.env.NEXTCLOUD_USER,
-    token: process.env.NEXTCLOUD_TOKEN
+    token: process.env.NEXTCLOUD_TOKEN,
+    // Optional. When set, created events name the account as a confirmed
+    // organiser and attendee; when unset, events are written exactly as before.
+    email: process.env.NEXTCLOUD_EMAIL || null
 };
 
 if (!CONFIG.url || !CONFIG.user || !CONFIG.token) {
@@ -175,6 +178,31 @@ function escapePropertyValue(value) {
     // Escape semicolons and commas which delimit structured values
     escaped = escaped.replace(/;/g, '\\;').replace(/,/g, '\\,');
     return escaped;
+}
+
+// RFC 5545 3.1: a parameter value is paramtext or a quoted-string, and neither
+// defines a backslash escape. escapePropertyValue() is the wrong tool here - it
+// would emit CN=Doe\, John, which a strict parser reads as two parameter
+// values. Quote when the value needs it, and drop what a quoted-string has no
+// way to represent.
+function escapeParameterValue(value) {
+    const cleaned = String(value)
+        .replace(/[\u0000-\u001F\u007F]+/g, ' ')
+        .replace(/"/g, "'");
+    return /[,;:]/.test(cleaned) ? `"${cleaned}"` : cleaned;
+}
+
+// NEXTCLOUD_EMAIL is interpolated into a mailto: URI on the ORGANIZER and
+// ATTENDEE lines, where a newline or a structural character would break out of
+// the property and inject one of its own. Reject rather than rewrite: an
+// address containing those is a misconfiguration, and quietly altering someone's
+// identity is worse than telling them it is wrong.
+function parseOrganizerEmail(value) {
+    const email = String(value).trim();
+    if (!/^[^\s@,;:"<>\\]+@[^\s@,;:"<>\\]+\.[^\s@,;:"<>\\]+$/.test(email)) {
+        throw new Error('NEXTCLOUD_EMAIL must be a plain email address, e.g. user@example.com.');
+    }
+    return email;
 }
 
 // Decode one layer of RFC 5545 / RFC 6350 text escaping when returning
@@ -1015,6 +1043,10 @@ const CalDAV = {
     // --- Calendar Events ---
 
     async createEvent(summary, start, end, calendarName, description, location) {
+        // Resolved before any network call so a malformed NEXTCLOUD_EMAIL is
+        // reported immediately rather than after calendar discovery has run.
+        const organizerEmail = CONFIG.email ? parseOrganizerEmail(CONFIG.email) : null;
+
         const cal = await this.getCalendar(calendarName, 'VEVENT');
         const uid = crypto.randomUUID();
         const now = new Date();
@@ -1029,6 +1061,18 @@ const CalDAV = {
 
         if (description) vevent += `DESCRIPTION:${escapePropertyValue(description)}\n`;
         if (location) vevent += `LOCATION:${escapePropertyValue(location)}\n`;
+
+        // With an address configured, name the account as the organiser and as
+        // an already-accepted attendee, so clients show the event as confirmed
+        // instead of as an invitation awaiting a reply. RSVP is deliberately
+        // omitted: asking for a response that PARTSTAT has already given is
+        // what produces the pending prompt this is meant to avoid.
+        if (organizerEmail) {
+            const cn = escapeParameterValue(CONFIG.user || organizerEmail.split('@')[0]);
+            vevent += `STATUS:CONFIRMED\n`;
+            vevent += `ORGANIZER;CN=${cn}:mailto:${organizerEmail}\n`;
+            vevent += `ATTENDEE;CN=${cn};ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:${organizerEmail}\n`;
+        }
 
         vevent += `END:VEVENT\nEND:VCALENDAR`;
 

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -17724,6 +17724,8 @@ var CONFIG = {
   url: process.env.NEXTCLOUD_URL,
   user: process.env.NEXTCLOUD_USER,
   token: process.env.NEXTCLOUD_TOKEN,
+  // Optional. When set, created events name the account as a confirmed
+  // organiser and attendee; when unset, events are written exactly as before.
   email: process.env.NEXTCLOUD_EMAIL || null
 };
 if (!CONFIG.url || !CONFIG.user || !CONFIG.token) {
@@ -17833,6 +17835,17 @@ function escapePropertyValue(value) {
   escaped = escaped.replace(/\r\n/g, "\\n").replace(/\n/g, "\\n").replace(/\r/g, "\\n");
   escaped = escaped.replace(/;/g, "\\;").replace(/,/g, "\\,");
   return escaped;
+}
+function escapeParameterValue(value) {
+  const cleaned = String(value).replace(/[\u0000-\u001F\u007F]+/g, " ").replace(/"/g, "'");
+  return /[,;:]/.test(cleaned) ? `"${cleaned}"` : cleaned;
+}
+function parseOrganizerEmail(value) {
+  const email = String(value).trim();
+  if (!/^[^\s@,;:"<>\\]+@[^\s@,;:"<>\\]+\.[^\s@,;:"<>\\]+$/.test(email)) {
+    throw new Error("NEXTCLOUD_EMAIL must be a plain email address, e.g. user@example.com.");
+  }
+  return email;
 }
 function unescapePropertyValue(value) {
   if (value === null || value === void 0) return value;
@@ -18539,6 +18552,7 @@ END:VCALENDAR`;
   },
   // --- Calendar Events ---
   async createEvent(summary, start, end, calendarName, description, location) {
+    const organizerEmail = CONFIG.email ? parseOrganizerEmail(CONFIG.email) : null;
     const cal = await this.getCalendar(calendarName, "VEVENT");
     const uid = crypto.randomUUID();
     const now = /* @__PURE__ */ new Date();
@@ -18561,14 +18575,13 @@ DTEND:${toCalDavDate(end)}
 `;
     if (location) vevent += `LOCATION:${escapePropertyValue(location)}
 `;
-    if (CONFIG.email) {
-      const email = CONFIG.email;
-      const cn = CONFIG.user || email.split("@")[0];
+    if (organizerEmail) {
+      const cn = escapeParameterValue(CONFIG.user || organizerEmail.split("@")[0]);
       vevent += `STATUS:CONFIRMED
 `;
-      vevent += `ORGANIZER;CN=${escapePropertyValue(cn)}:mailto:${email}
+      vevent += `ORGANIZER;CN=${cn}:mailto:${organizerEmail}
 `;
-      vevent += `ATTENDEE;CN=${escapePropertyValue(cn)};ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE:mailto:${email}
+      vevent += `ATTENDEE;CN=${cn};ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:${organizerEmail}
 `;
     }
     vevent += `END:VEVENT

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -17723,7 +17723,8 @@ import crypto from "node:crypto";
 var CONFIG = {
   url: process.env.NEXTCLOUD_URL,
   user: process.env.NEXTCLOUD_USER,
-  token: process.env.NEXTCLOUD_TOKEN
+  token: process.env.NEXTCLOUD_TOKEN,
+  email: process.env.NEXTCLOUD_EMAIL || null
 };
 if (!CONFIG.url || !CONFIG.user || !CONFIG.token) {
   console.error(JSON.stringify({
@@ -18560,6 +18561,16 @@ DTEND:${toCalDavDate(end)}
 `;
     if (location) vevent += `LOCATION:${escapePropertyValue(location)}
 `;
+    if (CONFIG.email) {
+      const email = CONFIG.email;
+      const cn = CONFIG.user || email.split("@")[0];
+      vevent += `STATUS:CONFIRMED
+`;
+      vevent += `ORGANIZER;CN=${escapePropertyValue(cn)}:mailto:${email}
+`;
+      vevent += `ATTENDEE;CN=${escapePropertyValue(cn)};ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE:mailto:${email}
+`;
+    }
     vevent += `END:VEVENT
 END:VCALENDAR`;
     const filename = `${uid}.ics`;

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -149,7 +149,7 @@ const server = http.createServer(async (req, res) => {
 
   res.statusCode = 200;
   if (req.method === 'PROPFIND' &&
-      req.url === '/remote.php/dav/calendars/tester/') {
+      /^\/remote\.php\/dav\/calendars\/[^/]+\/$/.test(req.url ?? '')) {
     res.setHeader('content-type', 'application/xml');
     res.end(calendarDiscovery);
   } else if (req.method === 'PROPFIND' &&
@@ -178,10 +178,15 @@ const env = {
   NEXTCLOUD_USER: 'tester',
   NEXTCLOUD_TOKEN: 'dummy-test-token'
 };
+// Optional, and read from the ambient environment — drop it so a developer who
+// has it set does not get different results from CI.
+delete env.NEXTCLOUD_EMAIL;
 
-function run(args) {
+function run(args, extraEnv = {}) {
   return new Promise(resolveRun => {
-    const child = spawn(process.execPath, [bundle, ...args], { env });
+    const child = spawn(process.execPath, [bundle, ...args], {
+      env: { ...env, ...extraEnv }
+    });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', chunk => stdout += chunk);
@@ -291,6 +296,84 @@ record(
     listedEvent?.description === 'Line one\nLine two' &&
     listedEvent?.location === 'Room; 2',
   { listedEvent, result }
+);
+
+// NEXTCLOUD_EMAIL is optional: unset, events must be written exactly as they
+// were before it existed.
+before = requests.length;
+result = await run([
+  'calendar', 'create',
+  '--summary', 'Plain event',
+  '--start', '2026-09-01T10:00:00',
+  '--end', '2026-09-01T11:00:00',
+  '--calendar', 'Personal'
+]);
+const plainPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'events carry no organiser when NEXTCLOUD_EMAIL is unset',
+  result.code === 0 &&
+    !plainPut?.body.includes('ORGANIZER') &&
+    !plainPut?.body.includes('ATTENDEE') &&
+    !plainPut?.body.includes('STATUS:'),
+  { body: plainPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run([
+  'calendar', 'create',
+  '--summary', 'Confirmed event',
+  '--start', '2026-09-01T10:00:00',
+  '--end', '2026-09-01T11:00:00',
+  '--calendar', 'Personal'
+], { NEXTCLOUD_EMAIL: 'tester@example.com' });
+const organizerPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'NEXTCLOUD_EMAIL marks the account as a confirmed organiser and attendee',
+  result.code === 0 &&
+    organizerPut?.body.includes('STATUS:CONFIRMED') &&
+    organizerPut?.body.includes('ORGANIZER;CN=tester:mailto:tester@example.com') &&
+    organizerPut?.body.includes(
+      'ATTENDEE;CN=tester;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:tester@example.com'
+    ) &&
+    // RSVP would ask for a reply PARTSTAT has already given, reinstating the
+    // pending prompt this feature exists to avoid.
+    !organizerPut?.body.includes('RSVP'),
+  { body: organizerPut?.body ?? null, result }
+);
+
+// A parameter value is not a property value: RFC 5545 defines no backslash
+// escape for it, so a comma has to be handled by quoting the whole value.
+before = requests.length;
+result = await run([
+  'calendar', 'create',
+  '--summary', 'Quoted CN',
+  '--start', '2026-09-01T10:00:00',
+  '--end', '2026-09-01T11:00:00',
+  '--calendar', 'Personal'
+], { NEXTCLOUD_USER: 'Doe, John', NEXTCLOUD_EMAIL: 'j@example.com' });
+const quotedPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'a comma in the display name is quoted rather than backslash-escaped',
+  result.code === 0 &&
+    quotedPut?.body.includes('ORGANIZER;CN="Doe, John":mailto:j@example.com') &&
+    !quotedPut?.body.includes('CN=Doe\\,'),
+  { body: quotedPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run([
+  'calendar', 'create',
+  '--summary', 'Injection attempt',
+  '--start', '2026-09-01T10:00:00',
+  '--end', '2026-09-01T11:00:00',
+  '--calendar', 'Personal'
+], { NEXTCLOUD_EMAIL: 'a@x.com\nDESCRIPTION:injected' });
+record(
+  'a newline in NEXTCLOUD_EMAIL is rejected before any request',
+  result.code !== 0 &&
+    result.stderr.includes('NEXTCLOUD_EMAIL must be a plain email address') &&
+    requests.length === before,
+  { result }
 );
 
 result = await run(['tasks', 'list', '--calendar', 'Personal']);


### PR DESCRIPTION
Emit STATUS:CONFIRMED, ORGANIZER, and ATTENDEE (PARTSTAT=ACCEPTED) on calendar create when NEXTCLOUD_EMAIL is set. Backward compatible: when the env var is unset, events are created exactly as before.

This lets calendar clients treat events as confirmed rather than pending RSVP.

it was tested against a real Nextcloud CalDAV server (3 cases: with email+location, with email no location, no email) and that the stored ICS carries STATUS:CONFIRMED + ATTENDEE;PARTSTAT=ACCEPTED