### PR TITLE
feat(tasks): add optional metadata fields (start, location, url, class, tags, status, percent-complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,14 @@ CalDAV form (`20260205T100000Z`).
 # List all tasks
 node scripts/nextcloud.js tasks list
 
-# Create a task
-node scripts/nextcloud.js tasks create --title "Buy groceries" --due "2026-02-05T17:00:00Z" --priority 1
+# Create a task with all optional metadata
+node scripts/nextcloud.js tasks create --title "Buy groceries" \
+  --due "2026-02-05T17:00:00Z" --priority 1 \
+  --start "2026-02-04T09:00:00Z" --location "Supermarket" \
+  --url "https://example.com" --class PRIVATE --tags "errands,shopping"
+
+# Update a task, including status and percent-complete
+node scripts/nextcloud.js tasks edit --uid task-uid --status IN-PROCESS --percent-complete 50
 
 # Complete a task
 node scripts/nextcloud.js tasks complete --uid task-uid

--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ node scripts/nextcloud.js calendar delete --uid event-uid \
 the URL slug, or the full collection URL — so all of `Personal`, `personal`,
 and `/remote.php/dav/calendars/<user>/personal/` resolve to the same calendar.
 Date inputs accept either ISO 8601 (`2026-02-05T10:00:00Z`) or the compact
-CalDAV form (`20260205T100000Z`).
+CalDAV form (`20260205T100000Z`). For tasks, a date with no time of day
+(`2026-02-05`) means all day; a task's `--start` and `--due` must both be
+all-day dates or both carry a time.
 
 ### Tasks
 
@@ -320,6 +322,9 @@ node scripts/nextcloud.js tasks create --title "Buy groceries" \
 
 # Update a task, including status and percent-complete
 node scripts/nextcloud.js tasks edit --uid task-uid --status IN-PROCESS --percent-complete 50
+
+# Clear a task's metadata by passing an empty value
+node scripts/nextcloud.js tasks edit --uid task-uid --tags "" --location "" --url ""
 
 # Complete a task
 node scripts/nextcloud.js tasks complete --uid task-uid

--- a/SKILL.md
+++ b/SKILL.md
@@ -181,6 +181,11 @@ password files.
 - `tasks delete --uid <u> [--calendar <c>] --confirm tasks:delete`
 - `tasks complete --uid <u> [--calendar <c>]`
 
+A date with no time of day (`2026-02-05`) makes an all-day task. A task's start
+and due dates must both be all-day or both carry a time, so pass `--start` and
+`--due` together to switch a task from one to the other. On `tasks edit`, an
+empty value (`--tags ""`) removes that property from the task.
+
 ### Calendar Events
 - `calendar list [--from <iso>] [--to <iso>]` (Defaults to next 7 days)
 - `calendar create --summary <s> --start <iso> --end <iso> [--calendar <c>] [--description <d> | --description-file <file>] [--location <l>]`

--- a/SKILL.md
+++ b/SKILL.md
@@ -176,8 +176,8 @@ password files.
 
 ### Tasks
 - `tasks list [--calendar <c>]`
-- `tasks create --title <t> [--calendar <c>] [--due <d>] [--priority <p>] [--description <d> | --description-file <file>]`
-- `tasks edit --uid <u> [--calendar <c>] [--title <t>] [--due <d>] [--priority <p>] [--description <d> | --description-file <file>]`
+- `tasks create --title <t> [--calendar <c>] [--start <d>] [--due <d>] [--priority <p>] [--description <d> | --description-file <file>] [--location <l>] [--url <u>] [--class PUBLIC|PRIVATE|CONFIDENTIAL] [--tags <comma-separated>]`
+- `tasks edit --uid <u> [--calendar <c>] [--title <t>] [--start <d>] [--due <d>] [--priority <p>] [--description <d> | --description-file <file>] [--location <l>] [--url <u>] [--class PUBLIC|PRIVATE|CONFIDENTIAL] [--tags <comma-separated>] [--status <s>] [--percent-complete <n>]`
 - `tasks delete --uid <u> [--calendar <c>] --confirm tasks:delete`
 - `tasks complete --uid <u> [--calendar <c>]`
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { Buffer } from 'node:buffer';
 import { XMLParser } from 'fast-xml-parser';
-import { addDays, formatISO, format } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import crypto from 'node:crypto';
 
 // --- Configuration ---
@@ -275,6 +275,18 @@ function parseClassInput(value) {
     return normalized;
 }
 
+// URL carries a URI value (RFC 5545 3.8.4.6), not TEXT, so the TEXT escaping of
+// commas and semicolons must not be applied to it — another client would render
+// the backslashes literally. Nothing needs escaping in a well-formed URI, so
+// reject the characters that would break the property line instead.
+function parseUriInput(value) {
+    const uri = String(value).trim();
+    if (/[\u0000-\u001F\u007F]/.test(uri) || /\s/.test(uri)) {
+        throw new Error('URL must be a single URI with no spaces or line breaks.');
+    }
+    return uri;
+}
+
 function parseTagsInput(value) {
     if (typeof value !== 'string' || value.trim() === '') {
         return [];
@@ -297,6 +309,9 @@ const CONFIRMATION_REQUIRED = new Set([
     'labels:delete'
 ]);
 
+// A flag that takes one value. An empty value is meaningful — on `tasks edit` it
+// clears the property — so it is returned as '', while the flag with no value at
+// all is a typo rather than a request to clear.
 function getOptionValue(args, flag) {
     const index = args.indexOf(flag);
     if (index === -1) return undefined;
@@ -414,8 +429,53 @@ function toCalDavDate(date) {
     return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
 }
 
-function validateTaskDates(startDate, dueDate) {
-    if (startDate && dueDate && startDate.getTime() > dueDate.getTime()) {
+// A DTSTART/DUE value as both an instant (for ordering) and the text to write,
+// keeping the RFC 5545 value type. A calendar date with no time of day is a
+// DATE — an all-day task — and writing it as midnight UTC instead would land it
+// on the previous day for anyone west of UTC.
+function parseCalendarValue(str) {
+    const raw = String(str).trim();
+    const dateOnly = /^(\d{4})-?(\d{2})-?(\d{2})$/.exec(raw);
+    if (dateOnly) {
+        const [, y, mo, d] = dateOnly;
+        const date = new Date(`${y}-${mo}-${d}T00:00:00Z`);
+        if (isNaN(date.getTime())) {
+            throw new Error(`Invalid date '${str}'. Use ISO 8601 (2026-04-15) or CalDAV compact format (20260415).`);
+        }
+        return { date, isDate: true, ical: `${y}${mo}${d}` };
+    }
+    const date = parseDateInput(raw);
+    return { date, isDate: false, ical: toCalDavDate(date) };
+}
+
+// Read a DTSTART/DUE back out of stored calendar data so an edit can be checked
+// against it. A value another client wrote in a form we cannot parse yields
+// null rather than an exception: it should not block an edit to a different
+// property of the same task.
+function readCalendarValue(text, prop) {
+    const match = text.match(new RegExp(`^${prop}(;[^:\r\n]*)?:(.*)$`, 'm'));
+    if (!match) return null;
+    try {
+        const value = parseCalendarValue(match[2].trim());
+        const declaredDate = /(?:^|;)VALUE=DATE(?:;|$)/i.test(match[1] || '');
+        return declaredDate ? { ...value, isDate: true } : value;
+    } catch {
+        return null;
+    }
+}
+
+// The ordering and value-type rules RFC 5545 3.6.2 puts on a VTODO's DTSTART
+// and DUE. Both arguments are parseCalendarValue() results, or null where the
+// task has no such property.
+function validateTaskDates(start, due) {
+    if (!start || !due) return;
+    if (start.isDate !== due.isDate) {
+        throw new Error(
+            "A task's start and due dates must both be all-day dates (2026-04-15) or both carry a " +
+            'time (2026-04-15T17:00:00Z). Set --start and --due together to change which form the task uses.'
+        );
+    }
+    if (start.date.getTime() > due.date.getTime()) {
         throw new Error('Start date must be earlier than or equal to due date.');
     }
 }
@@ -755,12 +815,8 @@ const CalDAV = {
         const calendars = await this.findCalendars('VEVENT');
         const allEvents = [];
 
-        const toCalDavDate = (dateStr) => {
-            const d = parseDateInput(dateStr);
-            return d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-        };
-        const startStr = toCalDavDate(start);
-        const endStr = toCalDavDate(end);
+        const startStr = toCalDavDate(parseDateInput(start));
+        const endStr = toCalDavDate(parseDateInput(end));
 
         const body = `
             <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -867,22 +923,26 @@ const CalDAV = {
                         continue; 
                      }
                      const calData = propstats[0]['d:prop']['cal:calendar-data'];
-                     const unfolded = calData.replace(/\r?\n[ \t]/g, '');
+                     // The VTODO's own lines only. A VCALENDAR that carries a VTIMEZONE has
+                     // DTSTART lines for the DST rules, and every match below is anchored so a
+                     // DESCRIPTION quoting "DUE:" cannot stand in for the property either.
+                     const vtodo = this._componentText(calData);
+                     if (!vtodo) continue;
 
-                     const summaryMatch = calData.match(/SUMMARY:(.*)/);
-                     const descriptionMatch = unfolded.match(/^DESCRIPTION(?:;[^:]*)?:(.*)$/m);
-                     // Anchored so REQUEST-STATUS, or a DESCRIPTION mentioning "STATUS:", cannot be
-                     // mistaken for the task's own status now that it decides visibility below.
-                     const statusMatch = unfolded.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
-                     const uidMatch = calData.match(/UID:(.*)/);
-                     const startMatch = calData.match(/DTSTART(?:;.*)?:(.*)/);
-                     const dueMatch = calData.match(/DUE(?:;.*)?:(.*)/);
-                     const priorityMatch = calData.match(/PRIORITY:(.*)/);
-                     const locationMatch = unfolded.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
-                     const urlMatch = unfolded.match(/^URL(?:;[^:]*)?:(.*)$/m);
-                     const classMatch = unfolded.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
-                     const categoriesMatch = unfolded.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
+                     const summaryMatch = vtodo.match(/^SUMMARY(?:;[^:]*)?:(.*)$/m);
+                     const descriptionMatch = vtodo.match(/^DESCRIPTION(?:;[^:]*)?:(.*)$/m);
+                     const statusMatch = vtodo.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
+                     const uidMatch = vtodo.match(/^UID(?:;[^:]*)?:(.*)$/m);
+                     const startMatch = vtodo.match(/^DTSTART(?:;[^:]*)?:(.*)$/m);
+                     const dueMatch = vtodo.match(/^DUE(?:;[^:]*)?:(.*)$/m);
+                     const priorityMatch = vtodo.match(/^PRIORITY(?:;[^:]*)?:(.*)$/m);
+                     const locationMatch = vtodo.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
+                     const urlMatch = vtodo.match(/^URL(?:;[^:]*)?:(.*)$/m);
+                     const classMatch = vtodo.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
+                     const categoriesMatch = vtodo.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
 
+                     // STATUS decides visibility below, so REQUEST-STATUS and a DESCRIPTION
+                     // mentioning "STATUS:" both have to be kept out of it.
                      const status = statusMatch ? statusMatch[1].trim() : 'NEEDS-ACTION';
                      // CalDAV prop-filter on STATUS only matches VTODOs where STATUS exists (RFC 4791 §3.6.4).
                      // Post-filter completed tasks so VTODOs with an implicit STATUS:NEEDS-ACTION
@@ -1008,26 +1068,72 @@ const CalDAV = {
         return null;
     },
     
-    _updateProperty(vcal, prop, value) {
-        if (value === null || value === undefined) {
-            return vcal;
+    // Index the lines belonging to the VTODO or VEVENT itself. Properties must
+    // never be read from or written to anything else in the VCALENDAR: a
+    // VTIMEZONE carries DTSTART lines of its own (the DST rules, dated 1970),
+    // and a VALARM carries its own SUMMARY and DESCRIPTION. An unscoped match
+    // finds whichever comes first in the file.
+    _componentLines(lines) {
+        let name = null;
+        let nested = 0;
+        const own = [];
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (!name) {
+                const begin = /^BEGIN:(VTODO|VEVENT)\s*$/.exec(line);
+                if (begin) name = begin[1];
+                continue;
+            }
+            if (nested === 0 && new RegExp(`^END:${name}\\s*$`).test(line)) {
+                return { name, own, end: i };
+            }
+            if (/^BEGIN:/.test(line)) nested++;
+            else if (/^END:/.test(line)) nested--;
+            else if (nested === 0) own.push(i);
         }
-        // Match an existing line including any property parameters (e.g. DUE;TZID=Europe/London:...).
-        const regex = new RegExp(`^${prop}(?:;[^:\\r\\n]*)?:.*$`, 'm');
-        const newLine = `${prop}:${value}`;
-        if (regex.test(vcal)) {
-            return vcal.replace(regex, () => newLine);
-        }
-        const endMatch = vcal.match(/END:(VTODO|VEVENT)/);
-        if (!endMatch) {
+        return null;
+    },
+
+    // The component's own property lines, unfolded, for reading values out of.
+    _componentText(vcal) {
+        const lines = vcal.replace(/\r?\n[ \t]/g, '').split(/\r?\n/);
+        const component = this._componentLines(lines);
+        return component ? component.own.map(i => lines[i]).join('\n') : '';
+    },
+
+    // Replace, insert, or (value === null) remove a property on the component.
+    _updateProperty(vcal, prop, value, params = null) {
+        if (value === undefined) return vcal;
+
+        const lines = vcal.split(/\r?\n/);
+        const component = this._componentLines(lines);
+        if (!component) {
             throw new Error('Cannot insert property: no END:VTODO or END:VEVENT found in calendar data.');
         }
-        return vcal.replace(endMatch[0], () => `${newLine}\n${endMatch[0]}`);
+
+        const eol = vcal.includes('\r\n') ? '\r\n' : '\n';
+        const newLine = value === null ? null : `${prop}${params ? `;${params}` : ''}:${value}`;
+        // Match an existing line including any property parameters (e.g. DUE;TZID=Europe/London:...).
+        const regex = new RegExp(`^${prop}(?:;[^:]*)?:`);
+        const first = component.own.find(i => regex.test(lines[i]));
+
+        if (first === undefined) {
+            if (newLine === null) return vcal;
+            lines.splice(component.end, 0, newLine);
+            return lines.join(eol);
+        }
+
+        // A value longer than 75 octets is folded across continuation lines
+        // (RFC 5545 3.1); they are part of this property and go with it.
+        let last = first;
+        while (last + 1 < lines.length && /^[ \t]/.test(lines[last + 1])) last++;
+        lines.splice(first, last - first + 1, ...(newLine === null ? [] : [newLine]));
+        return lines.join(eol);
     },
 
     async createTask(title, calendarName, options = {}) {
-        const start = options.startDate ? parseDateInput(options.startDate) : null;
-        const due = options.dueDate ? parseDateInput(options.dueDate) : null;
+        const start = options.startDate ? parseCalendarValue(options.startDate) : null;
+        const due = options.dueDate ? parseCalendarValue(options.dueDate) : null;
         validateTaskDates(start, due);
 
         const cal = await this.getCalendar(calendarName, 'VTODO');
@@ -1037,13 +1143,13 @@ const CalDAV = {
 
         let vtodo = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//OpenClaw//Nextcloud Skill//EN\nBEGIN:VTODO\nUID:${uid}\nDTSTAMP:${dtstamp}\nSUMMARY:${escapePropertyValue(title)}\nSTATUS:NEEDS-ACTION\n`;
 
-        if (start) vtodo += `DTSTART:${toCalDavDate(start)}\n`;
-        if (due) vtodo += `DUE:${toCalDavDate(due)}\n`;
+        if (start) vtodo += `DTSTART${start.isDate ? ';VALUE=DATE' : ''}:${start.ical}\n`;
+        if (due) vtodo += `DUE${due.isDate ? ';VALUE=DATE' : ''}:${due.ical}\n`;
 
         if (options.priority) vtodo += `PRIORITY:${options.priority}\n`;
         if (options.description) vtodo += `DESCRIPTION:${escapePropertyValue(options.description)}\n`;
         if (options.location) vtodo += `LOCATION:${escapePropertyValue(options.location)}\n`;
-        if (options.url) vtodo += `URL:${escapePropertyValue(options.url)}\n`;
+        if (options.url) vtodo += `URL:${options.url}\n`;
         if (options.className) vtodo += `CLASS:${options.className}\n`;
         if (options.tags && options.tags.length > 0) {
             vtodo += `CATEGORIES:${options.tags.map(escapePropertyValue).join(',')}\n`;
@@ -1077,33 +1183,37 @@ const CalDAV = {
         if (updates.priority) vtodo = this._updateProperty(vtodo, 'PRIORITY', updates.priority);
         if (updates.description) vtodo = this._updateProperty(vtodo, 'DESCRIPTION', escapePropertyValue(updates.description));
         if (updates.startDate || updates.dueDate) {
-            const start = updates.startDate ? parseDateInput(updates.startDate) : null;
-            const due = updates.dueDate ? parseDateInput(updates.dueDate) : null;
-            // Validate against the existing dates when only one side is being changed.
-            const existingStartMatch = vtodo.match(/DTSTART(?:;.*)?:(.*)/);
-            const existingDueMatch = vtodo.match(/DUE(?:;.*)?:(.*)/);
-            const existingStart = existingStartMatch ? parseDateInput(existingStartMatch[1].trim()) : null;
-            const existingDue = existingDueMatch ? parseDateInput(existingDueMatch[1].trim()) : null;
-            validateTaskDates(start || existingStart, due || existingDue);
+            const start = updates.startDate ? parseCalendarValue(updates.startDate) : null;
+            const due = updates.dueDate ? parseCalendarValue(updates.dueDate) : null;
+            // Check against the stored dates when only one side is being changed, reading
+            // them from the VTODO itself so a VTIMEZONE's DST rules cannot stand in for
+            // the task's own start.
+            const stored = this._componentText(vtodo);
+            validateTaskDates(
+                start || readCalendarValue(stored, 'DTSTART'),
+                due || readCalendarValue(stored, 'DUE')
+            );
 
-            if (start) vtodo = this._updateProperty(vtodo, 'DTSTART', toCalDavDate(start));
-            if (due) vtodo = this._updateProperty(vtodo, 'DUE', toCalDavDate(due));
+            if (start) vtodo = this._updateProperty(vtodo, 'DTSTART', start.ical, start.isDate ? 'VALUE=DATE' : null);
+            if (due) vtodo = this._updateProperty(vtodo, 'DUE', due.ical, due.isDate ? 'VALUE=DATE' : null);
         }
         if (updates.location !== undefined) {
             vtodo = this._updateProperty(vtodo, 'LOCATION', updates.location === null ? null : escapePropertyValue(updates.location));
         }
         if (updates.url !== undefined) {
-            vtodo = this._updateProperty(vtodo, 'URL', updates.url === null ? null : escapePropertyValue(updates.url));
+            vtodo = this._updateProperty(vtodo, 'URL', updates.url);
         }
         if (updates.className !== undefined) {
             vtodo = this._updateProperty(vtodo, 'CLASS', updates.className);
         }
         if (updates.tags !== undefined) {
-            if (updates.tags === null || updates.tags.length === 0) {
-                vtodo = this._updateProperty(vtodo, 'CATEGORIES', null);
-            } else {
-                vtodo = this._updateProperty(vtodo, 'CATEGORIES', updates.tags.map(escapePropertyValue).join(','));
-            }
+            vtodo = this._updateProperty(
+                vtodo,
+                'CATEGORIES',
+                updates.tags === null || updates.tags.length === 0
+                    ? null
+                    : updates.tags.map(escapePropertyValue).join(',')
+            );
         }
 
         if (updates.status) vtodo = this._updateProperty(vtodo, 'STATUS', updates.status);
@@ -1136,7 +1246,7 @@ const CalDAV = {
         
         let vtodo = task.data;
         const now = new Date();
-        const completedDate = format(now, "yyyyMMdd'T'HHmmss'Z'");
+        const completedDate = toCalDavDate(now);
         
         vtodo = this._updateProperty(vtodo, 'STATUS', 'COMPLETED');
         vtodo = this._updateProperty(vtodo, 'COMPLETED', completedDate);
@@ -1163,14 +1273,9 @@ const CalDAV = {
         const cal = await this.getCalendar(calendarName, 'VEVENT');
         const uid = crypto.randomUUID();
         const now = new Date();
-        const dtstamp = format(now, "yyyyMMdd'T'HHmmss'Z'");
+        const dtstamp = toCalDavDate(now);
 
-        const toCalDavDate = (dateStr) => {
-            const d = parseDateInput(dateStr);
-            return d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-        };
-
-        let vevent = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//OpenClaw//Nextcloud Skill//EN\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtstamp}\nSUMMARY:${escapePropertyValue(summary)}\nDTSTART:${toCalDavDate(start)}\nDTEND:${toCalDavDate(end)}\n`;
+        let vevent = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//OpenClaw//Nextcloud Skill//EN\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtstamp}\nSUMMARY:${escapePropertyValue(summary)}\nDTSTART:${toCalDavDate(parseDateInput(start))}\nDTEND:${toCalDavDate(parseDateInput(end))}\n`;
 
         if (description) vevent += `DESCRIPTION:${escapePropertyValue(description)}\n`;
         if (location) vevent += `LOCATION:${escapePropertyValue(location)}\n`;
@@ -1270,11 +1375,11 @@ const CalDAV = {
         if (updates.summary) vevent = this._updateProperty(vevent, 'SUMMARY', escapePropertyValue(updates.summary));
         if (updates.start) {
             const d = parseDateInput(updates.start);
-            vevent = this._updateProperty(vevent, 'DTSTART', d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z');
+            vevent = this._updateProperty(vevent, 'DTSTART', toCalDavDate(d));
         }
         if (updates.end) {
             const d = parseDateInput(updates.end);
-            vevent = this._updateProperty(vevent, 'DTEND', d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z');
+            vevent = this._updateProperty(vevent, 'DTEND', toCalDavDate(d));
         }
         if (updates.description !== undefined) {
             vevent = this._updateProperty(vevent, 'DESCRIPTION', escapePropertyValue(updates.description));
@@ -2309,20 +2414,20 @@ async function main() {
                     description
                 };
 
-                const startIndex = args.indexOf('--start');
-                if (startIndex !== -1) options.startDate = args[startIndex + 1];
+                const start = getOptionValue(args, '--start');
+                if (start) options.startDate = start;
 
-                const locIndex = args.indexOf('--location');
-                if (locIndex !== -1) options.location = args[locIndex + 1];
+                const location = getOptionValue(args, '--location');
+                if (location) options.location = location;
 
-                const urlIndex = args.indexOf('--url');
-                if (urlIndex !== -1) options.url = args[urlIndex + 1];
+                const url = getOptionValue(args, '--url');
+                if (url) options.url = parseUriInput(url);
 
-                const classIndex = args.indexOf('--class');
-                if (classIndex !== -1) options.className = parseClassInput(args[classIndex + 1]);
+                const className = getOptionValue(args, '--class');
+                if (className) options.className = parseClassInput(className);
 
-                const tagsIndex = args.indexOf('--tags');
-                if (tagsIndex !== -1) options.tags = parseTagsInput(args[tagsIndex + 1]);
+                const tags = getOptionValue(args, '--tags');
+                if (tags) options.tags = parseTagsInput(tags);
 
                 output(await CalDAV.createTask(title, calendar, options));
 
@@ -2351,20 +2456,21 @@ async function main() {
                 );
                 if (description !== undefined) updates.description = description;
 
-                const startIndex = args.indexOf('--start');
-                if (startIndex !== -1) updates.startDate = args[startIndex + 1];
+                const start = getOptionValue(args, '--start');
+                if (start) updates.startDate = start;
 
-                const locIndex = args.indexOf('--location');
-                if (locIndex !== -1) updates.location = args[locIndex + 1];
+                // For these four, an empty value removes the property from the task.
+                const location = getOptionValue(args, '--location');
+                if (location !== undefined) updates.location = location === '' ? null : location;
 
-                const urlIndex = args.indexOf('--url');
-                if (urlIndex !== -1) updates.url = args[urlIndex + 1];
+                const url = getOptionValue(args, '--url');
+                if (url !== undefined) updates.url = url === '' ? null : parseUriInput(url);
 
-                const classIndex = args.indexOf('--class');
-                if (classIndex !== -1) updates.className = parseClassInput(args[classIndex + 1]);
+                const className = getOptionValue(args, '--class');
+                if (className !== undefined) updates.className = className === '' ? null : parseClassInput(className);
 
-                const tagsIndex = args.indexOf('--tags');
-                if (tagsIndex !== -1) updates.tags = parseTagsInput(args[tagsIndex + 1]);
+                const tags = getOptionValue(args, '--tags');
+                if (tags !== undefined) updates.tags = parseTagsInput(tags);
 
                 const statusIndex = args.indexOf('--status');
                 if (statusIndex !== -1) {

--- a/index.js
+++ b/index.js
@@ -245,6 +245,43 @@ function parsePriorityInput(value) {
     return String(value);
 }
 
+function parseStatusInput(value) {
+    const normalized = String(value).toUpperCase();
+    const validStatuses = ['NEEDS-ACTION', 'IN-PROCESS', 'COMPLETED', 'CANCELLED'];
+    if (!validStatuses.includes(normalized)) {
+        throw new Error(`Invalid status '${value}'. Valid values: ${validStatuses.join(', ')}.`);
+    }
+    return normalized;
+}
+
+function parsePercentCompleteInput(value) {
+    const str = String(value);
+    if (!/^\d{1,3}$/.test(str)) {
+        throw new Error('Percent-complete must be an integer from 0 to 100.');
+    }
+    const num = parseInt(str, 10);
+    if (num < 0 || num > 100) {
+        throw new Error('Percent-complete must be between 0 and 100.');
+    }
+    return String(num);
+}
+
+function parseClassInput(value) {
+    const normalized = String(value).toUpperCase();
+    const validClasses = ['PUBLIC', 'PRIVATE', 'CONFIDENTIAL'];
+    if (!validClasses.includes(normalized)) {
+        throw new Error(`Invalid class '${value}'. Valid values: ${validClasses.join(', ')}.`);
+    }
+    return normalized;
+}
+
+function parseTagsInput(value) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return [];
+    }
+    return value.split(',').map(tag => tag.trim()).filter(Boolean);
+}
+
 const MAX_TEXT_INPUT_BYTES = 64 * 1024 * 1024;
 const CONFIRMATION_REQUIRED = new Set([
     'notes:delete',
@@ -371,6 +408,16 @@ function parseDateInput(str) {
         throw new Error(`Invalid date '${str}'. Use ISO 8601 (2026-04-15T17:00:00Z) or CalDAV compact format (20260415T170000Z).`);
     }
     return date;
+}
+
+function toCalDavDate(date) {
+    return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function validateTaskDates(startDate, dueDate) {
+    if (startDate && dueDate && startDate.getTime() > dueDate.getTime()) {
+        throw new Error('Start date must be earlier than or equal to due date.');
+    }
 }
 
 // --- Modules ---
@@ -828,8 +875,13 @@ const CalDAV = {
                      // mistaken for the task's own status now that it decides visibility below.
                      const statusMatch = unfolded.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
                      const uidMatch = calData.match(/UID:(.*)/);
+                     const startMatch = calData.match(/DTSTART(?:;.*)?:(.*)/);
                      const dueMatch = calData.match(/DUE(?:;.*)?:(.*)/);
                      const priorityMatch = calData.match(/PRIORITY:(.*)/);
+                     const locationMatch = unfolded.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
+                     const urlMatch = unfolded.match(/^URL(?:;[^:]*)?:(.*)$/m);
+                     const classMatch = unfolded.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
+                     const categoriesMatch = unfolded.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
 
                      const status = statusMatch ? statusMatch[1].trim() : 'NEEDS-ACTION';
                      // CalDAV prop-filter on STATUS only matches VTODOs where STATUS exists (RFC 4791 §3.6.4).
@@ -837,14 +889,39 @@ const CalDAV = {
                      // (e.g. todos created by the Nextcloud Tasks web UI) are still returned.
                      if (status === 'COMPLETED') continue;
 
+                     let tags = null;
+                     if (categoriesMatch) {
+                         const rawTags = categoriesMatch[1].trim();
+                         const split = [];
+                         let current = '';
+                         for (let i = 0; i < rawTags.length; i++) {
+                             const char = rawTags[i];
+                             if (char === '\\' && i + 1 < rawTags.length) {
+                                 current += char + rawTags[++i];
+                             } else if (char === ',') {
+                                 split.push(current);
+                                 current = '';
+                             } else {
+                                 current += char;
+                             }
+                         }
+                         split.push(current);
+                         tags = split.map(t => unescapePropertyValue(t.trim())).filter(Boolean);
+                     }
+
                      allTodos.push({
                          uid: uidMatch ? uidMatch[1].trim() : 'No UID',
                          calendar: cal.displayname,
                          summary: summaryMatch ? unescapePropertyValue(summaryMatch[1].trim()) : 'No Title',
                          description: descriptionMatch ? unescapePropertyValue(descriptionMatch[1].trim()) : null,
                          status: status,
+                         start: startMatch ? startMatch[1].trim() : null,
                          due: dueMatch ? dueMatch[1].trim() : null,
-                         priority: priorityMatch ? parseInt(priorityMatch[1].trim(), 10) : null
+                         priority: priorityMatch ? parseInt(priorityMatch[1].trim(), 10) : null,
+                         location: locationMatch ? unescapePropertyValue(locationMatch[1].trim()) : null,
+                         url: urlMatch ? unescapePropertyValue(urlMatch[1].trim()) : null,
+                         class: classMatch ? classMatch[1].trim().toUpperCase() : null,
+                         tags: tags
                      });
                  }
              } catch (e) {
@@ -948,21 +1025,29 @@ const CalDAV = {
         return vcal.replace(endMatch[0], () => `${newLine}\n${endMatch[0]}`);
     },
 
-    async createTask(title, calendarName, dueDate, priority, description) {
+    async createTask(title, calendarName, options = {}) {
+        const start = options.startDate ? parseDateInput(options.startDate) : null;
+        const due = options.dueDate ? parseDateInput(options.dueDate) : null;
+        validateTaskDates(start, due);
+
         const cal = await this.getCalendar(calendarName, 'VTODO');
         const uid = crypto.randomUUID();
         const now = new Date();
-        const dtstamp = format(now, "yyyyMMdd'T'HHmmss'Z'");
+        const dtstamp = toCalDavDate(now);
 
         let vtodo = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//OpenClaw//Nextcloud Skill//EN\nBEGIN:VTODO\nUID:${uid}\nDTSTAMP:${dtstamp}\nSUMMARY:${escapePropertyValue(title)}\nSTATUS:NEEDS-ACTION\n`;
 
-        if (dueDate) {
-             const due = parseDateInput(dueDate);
-             vtodo += `DUE:${format(due, "yyyyMMdd'T'HHmmss'Z'")}\n`;
-        }
+        if (start) vtodo += `DTSTART:${toCalDavDate(start)}\n`;
+        if (due) vtodo += `DUE:${toCalDavDate(due)}\n`;
 
-        if (priority) vtodo += `PRIORITY:${priority}\n`;
-        if (description) vtodo += `DESCRIPTION:${escapePropertyValue(description)}\n`;
+        if (options.priority) vtodo += `PRIORITY:${options.priority}\n`;
+        if (options.description) vtodo += `DESCRIPTION:${escapePropertyValue(options.description)}\n`;
+        if (options.location) vtodo += `LOCATION:${escapePropertyValue(options.location)}\n`;
+        if (options.url) vtodo += `URL:${escapePropertyValue(options.url)}\n`;
+        if (options.className) vtodo += `CLASS:${options.className}\n`;
+        if (options.tags && options.tags.length > 0) {
+            vtodo += `CATEGORIES:${options.tags.map(escapePropertyValue).join(',')}\n`;
+        }
 
         vtodo += `END:VTODO\nEND:VCALENDAR`;
 
@@ -991,10 +1076,38 @@ const CalDAV = {
         if (updates.title) vtodo = this._updateProperty(vtodo, 'SUMMARY', escapePropertyValue(updates.title));
         if (updates.priority) vtodo = this._updateProperty(vtodo, 'PRIORITY', updates.priority);
         if (updates.description) vtodo = this._updateProperty(vtodo, 'DESCRIPTION', escapePropertyValue(updates.description));
-        if (updates.dueDate) {
-             const due = parseDateInput(updates.dueDate);
-             vtodo = this._updateProperty(vtodo, 'DUE', format(due, "yyyyMMdd'T'HHmmss'Z'"));
+        if (updates.startDate || updates.dueDate) {
+            const start = updates.startDate ? parseDateInput(updates.startDate) : null;
+            const due = updates.dueDate ? parseDateInput(updates.dueDate) : null;
+            // Validate against the existing dates when only one side is being changed.
+            const existingStartMatch = vtodo.match(/DTSTART(?:;.*)?:(.*)/);
+            const existingDueMatch = vtodo.match(/DUE(?:;.*)?:(.*)/);
+            const existingStart = existingStartMatch ? parseDateInput(existingStartMatch[1].trim()) : null;
+            const existingDue = existingDueMatch ? parseDateInput(existingDueMatch[1].trim()) : null;
+            validateTaskDates(start || existingStart, due || existingDue);
+
+            if (start) vtodo = this._updateProperty(vtodo, 'DTSTART', toCalDavDate(start));
+            if (due) vtodo = this._updateProperty(vtodo, 'DUE', toCalDavDate(due));
         }
+        if (updates.location !== undefined) {
+            vtodo = this._updateProperty(vtodo, 'LOCATION', updates.location === null ? null : escapePropertyValue(updates.location));
+        }
+        if (updates.url !== undefined) {
+            vtodo = this._updateProperty(vtodo, 'URL', updates.url === null ? null : escapePropertyValue(updates.url));
+        }
+        if (updates.className !== undefined) {
+            vtodo = this._updateProperty(vtodo, 'CLASS', updates.className);
+        }
+        if (updates.tags !== undefined) {
+            if (updates.tags === null || updates.tags.length === 0) {
+                vtodo = this._updateProperty(vtodo, 'CATEGORIES', null);
+            } else {
+                vtodo = this._updateProperty(vtodo, 'CATEGORIES', updates.tags.map(escapePropertyValue).join(','));
+            }
+        }
+
+        if (updates.status) vtodo = this._updateProperty(vtodo, 'STATUS', updates.status);
+        if (updates.percentComplete !== undefined) vtodo = this._updateProperty(vtodo, 'PERCENT-COMPLETE', updates.percentComplete);
 
         await request(task.href, {
             method: 'PUT',
@@ -2188,7 +2301,30 @@ async function main() {
                     args, '--description', '--description-file'
                 ) ?? null;
 
-                output(await CalDAV.createTask(title, calendar, dueDate, priority, description));
+                const options = {
+                    title,
+                    calendar,
+                    dueDate,
+                    priority,
+                    description
+                };
+
+                const startIndex = args.indexOf('--start');
+                if (startIndex !== -1) options.startDate = args[startIndex + 1];
+
+                const locIndex = args.indexOf('--location');
+                if (locIndex !== -1) options.location = args[locIndex + 1];
+
+                const urlIndex = args.indexOf('--url');
+                if (urlIndex !== -1) options.url = args[urlIndex + 1];
+
+                const classIndex = args.indexOf('--class');
+                if (classIndex !== -1) options.className = parseClassInput(args[classIndex + 1]);
+
+                const tagsIndex = args.indexOf('--tags');
+                if (tagsIndex !== -1) options.tags = parseTagsInput(args[tagsIndex + 1]);
+
+                output(await CalDAV.createTask(title, calendar, options));
 
              } else if (subCommand === 'edit') {
                 const uidIndex = args.indexOf('--uid');
@@ -2214,6 +2350,31 @@ async function main() {
                     args, '--description', '--description-file'
                 );
                 if (description !== undefined) updates.description = description;
+
+                const startIndex = args.indexOf('--start');
+                if (startIndex !== -1) updates.startDate = args[startIndex + 1];
+
+                const locIndex = args.indexOf('--location');
+                if (locIndex !== -1) updates.location = args[locIndex + 1];
+
+                const urlIndex = args.indexOf('--url');
+                if (urlIndex !== -1) updates.url = args[urlIndex + 1];
+
+                const classIndex = args.indexOf('--class');
+                if (classIndex !== -1) updates.className = parseClassInput(args[classIndex + 1]);
+
+                const tagsIndex = args.indexOf('--tags');
+                if (tagsIndex !== -1) updates.tags = parseTagsInput(args[tagsIndex + 1]);
+
+                const statusIndex = args.indexOf('--status');
+                if (statusIndex !== -1) {
+                    updates.status = parseStatusInput(args[statusIndex + 1]);
+                }
+
+                const percentIndex = args.indexOf('--percent-complete');
+                if (percentIndex !== -1) {
+                    updates.percentComplete = parsePercentCompleteInput(args[percentIndex + 1]);
+                }
 
                 output(await CalDAV.updateTask(uid, calendar, updates));
 

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -17877,6 +17877,39 @@ function parsePriorityInput(value) {
   }
   return String(value);
 }
+function parseStatusInput(value) {
+  const normalized = String(value).toUpperCase();
+  const validStatuses = ["NEEDS-ACTION", "IN-PROCESS", "COMPLETED", "CANCELLED"];
+  if (!validStatuses.includes(normalized)) {
+    throw new Error(`Invalid status '${value}'. Valid values: ${validStatuses.join(", ")}.`);
+  }
+  return normalized;
+}
+function parsePercentCompleteInput(value) {
+  const str = String(value);
+  if (!/^\d{1,3}$/.test(str)) {
+    throw new Error("Percent-complete must be an integer from 0 to 100.");
+  }
+  const num = parseInt(str, 10);
+  if (num < 0 || num > 100) {
+    throw new Error("Percent-complete must be between 0 and 100.");
+  }
+  return String(num);
+}
+function parseClassInput(value) {
+  const normalized = String(value).toUpperCase();
+  const validClasses = ["PUBLIC", "PRIVATE", "CONFIDENTIAL"];
+  if (!validClasses.includes(normalized)) {
+    throw new Error(`Invalid class '${value}'. Valid values: ${validClasses.join(", ")}.`);
+  }
+  return normalized;
+}
+function parseTagsInput(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return [];
+  }
+  return value.split(",").map((tag) => tag.trim()).filter(Boolean);
+}
 var MAX_TEXT_INPUT_BYTES = 64 * 1024 * 1024;
 var CONFIRMATION_REQUIRED = /* @__PURE__ */ new Set([
   "notes:delete",
@@ -17987,6 +18020,14 @@ function parseDateInput(str) {
     throw new Error(`Invalid date '${str}'. Use ISO 8601 (2026-04-15T17:00:00Z) or CalDAV compact format (20260415T170000Z).`);
   }
   return date;
+}
+function toCalDavDate(date) {
+  return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+}
+function validateTaskDates(startDate, dueDate) {
+  if (startDate && dueDate && startDate.getTime() > dueDate.getTime()) {
+    throw new Error("Start date must be earlier than or equal to due date.");
+  }
 }
 var Notes = {
   async list() {
@@ -18259,12 +18300,12 @@ var CalDAV = {
   async getEvents(start, end) {
     const calendars = await this.findCalendars("VEVENT");
     const allEvents = [];
-    const toCalDavDate = (dateStr) => {
+    const toCalDavDate2 = (dateStr) => {
       const d = parseDateInput(dateStr);
       return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
     };
-    const startStr = toCalDavDate(start);
-    const endStr = toCalDavDate(end);
+    const startStr = toCalDavDate2(start);
+    const endStr = toCalDavDate2(end);
     const body = `
             <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
                 <d:prop>
@@ -18360,18 +18401,47 @@ var CalDAV = {
           const descriptionMatch = unfolded.match(/^DESCRIPTION(?:;[^:]*)?:(.*)$/m);
           const statusMatch = unfolded.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
           const uidMatch = calData.match(/UID:(.*)/);
+          const startMatch = calData.match(/DTSTART(?:;.*)?:(.*)/);
           const dueMatch = calData.match(/DUE(?:;.*)?:(.*)/);
           const priorityMatch = calData.match(/PRIORITY:(.*)/);
+          const locationMatch = unfolded.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
+          const urlMatch = unfolded.match(/^URL(?:;[^:]*)?:(.*)$/m);
+          const classMatch = unfolded.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
+          const categoriesMatch = unfolded.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
           const status = statusMatch ? statusMatch[1].trim() : "NEEDS-ACTION";
           if (status === "COMPLETED") continue;
+          let tags = null;
+          if (categoriesMatch) {
+            const rawTags = categoriesMatch[1].trim();
+            const split = [];
+            let current = "";
+            for (let i = 0; i < rawTags.length; i++) {
+              const char = rawTags[i];
+              if (char === "\\" && i + 1 < rawTags.length) {
+                current += char + rawTags[++i];
+              } else if (char === ",") {
+                split.push(current);
+                current = "";
+              } else {
+                current += char;
+              }
+            }
+            split.push(current);
+            tags = split.map((t) => unescapePropertyValue(t.trim())).filter(Boolean);
+          }
           allTodos.push({
             uid: uidMatch ? uidMatch[1].trim() : "No UID",
             calendar: cal.displayname,
             summary: summaryMatch ? unescapePropertyValue(summaryMatch[1].trim()) : "No Title",
             description: descriptionMatch ? unescapePropertyValue(descriptionMatch[1].trim()) : null,
             status,
+            start: startMatch ? startMatch[1].trim() : null,
             due: dueMatch ? dueMatch[1].trim() : null,
-            priority: priorityMatch ? parseInt(priorityMatch[1].trim(), 10) : null
+            priority: priorityMatch ? parseInt(priorityMatch[1].trim(), 10) : null,
+            location: locationMatch ? unescapePropertyValue(locationMatch[1].trim()) : null,
+            url: urlMatch ? unescapePropertyValue(urlMatch[1].trim()) : null,
+            class: classMatch ? classMatch[1].trim().toUpperCase() : null,
+            tags
           });
         }
       } catch (e) {
@@ -18464,11 +18534,14 @@ var CalDAV = {
     return vcal.replace(endMatch[0], () => `${newLine}
 ${endMatch[0]}`);
   },
-  async createTask(title, calendarName, dueDate, priority, description) {
+  async createTask(title, calendarName, options = {}) {
+    const start = options.startDate ? parseDateInput(options.startDate) : null;
+    const due = options.dueDate ? parseDateInput(options.dueDate) : null;
+    validateTaskDates(start, due);
     const cal = await this.getCalendar(calendarName, "VTODO");
     const uid = crypto.randomUUID();
     const now = /* @__PURE__ */ new Date();
-    const dtstamp = (0, import_date_fns.format)(now, "yyyyMMdd'T'HHmmss'Z'");
+    const dtstamp = toCalDavDate(now);
     let vtodo = `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//OpenClaw//Nextcloud Skill//EN
@@ -18478,15 +18551,24 @@ DTSTAMP:${dtstamp}
 SUMMARY:${escapePropertyValue(title)}
 STATUS:NEEDS-ACTION
 `;
-    if (dueDate) {
-      const due = parseDateInput(dueDate);
-      vtodo += `DUE:${(0, import_date_fns.format)(due, "yyyyMMdd'T'HHmmss'Z'")}
+    if (start) vtodo += `DTSTART:${toCalDavDate(start)}
+`;
+    if (due) vtodo += `DUE:${toCalDavDate(due)}
+`;
+    if (options.priority) vtodo += `PRIORITY:${options.priority}
+`;
+    if (options.description) vtodo += `DESCRIPTION:${escapePropertyValue(options.description)}
+`;
+    if (options.location) vtodo += `LOCATION:${escapePropertyValue(options.location)}
+`;
+    if (options.url) vtodo += `URL:${escapePropertyValue(options.url)}
+`;
+    if (options.className) vtodo += `CLASS:${options.className}
+`;
+    if (options.tags && options.tags.length > 0) {
+      vtodo += `CATEGORIES:${options.tags.map(escapePropertyValue).join(",")}
 `;
     }
-    if (priority) vtodo += `PRIORITY:${priority}
-`;
-    if (description) vtodo += `DESCRIPTION:${escapePropertyValue(description)}
-`;
     vtodo += `END:VTODO
 END:VCALENDAR`;
     const filename = `${uid}.ics`;
@@ -18509,10 +18591,35 @@ END:VCALENDAR`;
     if (updates.title) vtodo = this._updateProperty(vtodo, "SUMMARY", escapePropertyValue(updates.title));
     if (updates.priority) vtodo = this._updateProperty(vtodo, "PRIORITY", updates.priority);
     if (updates.description) vtodo = this._updateProperty(vtodo, "DESCRIPTION", escapePropertyValue(updates.description));
-    if (updates.dueDate) {
-      const due = parseDateInput(updates.dueDate);
-      vtodo = this._updateProperty(vtodo, "DUE", (0, import_date_fns.format)(due, "yyyyMMdd'T'HHmmss'Z'"));
+    if (updates.startDate || updates.dueDate) {
+      const start = updates.startDate ? parseDateInput(updates.startDate) : null;
+      const due = updates.dueDate ? parseDateInput(updates.dueDate) : null;
+      const existingStartMatch = vtodo.match(/DTSTART(?:;.*)?:(.*)/);
+      const existingDueMatch = vtodo.match(/DUE(?:;.*)?:(.*)/);
+      const existingStart = existingStartMatch ? parseDateInput(existingStartMatch[1].trim()) : null;
+      const existingDue = existingDueMatch ? parseDateInput(existingDueMatch[1].trim()) : null;
+      validateTaskDates(start || existingStart, due || existingDue);
+      if (start) vtodo = this._updateProperty(vtodo, "DTSTART", toCalDavDate(start));
+      if (due) vtodo = this._updateProperty(vtodo, "DUE", toCalDavDate(due));
     }
+    if (updates.location !== void 0) {
+      vtodo = this._updateProperty(vtodo, "LOCATION", updates.location === null ? null : escapePropertyValue(updates.location));
+    }
+    if (updates.url !== void 0) {
+      vtodo = this._updateProperty(vtodo, "URL", updates.url === null ? null : escapePropertyValue(updates.url));
+    }
+    if (updates.className !== void 0) {
+      vtodo = this._updateProperty(vtodo, "CLASS", updates.className);
+    }
+    if (updates.tags !== void 0) {
+      if (updates.tags === null || updates.tags.length === 0) {
+        vtodo = this._updateProperty(vtodo, "CATEGORIES", null);
+      } else {
+        vtodo = this._updateProperty(vtodo, "CATEGORIES", updates.tags.map(escapePropertyValue).join(","));
+      }
+    }
+    if (updates.status) vtodo = this._updateProperty(vtodo, "STATUS", updates.status);
+    if (updates.percentComplete !== void 0) vtodo = this._updateProperty(vtodo, "PERCENT-COMPLETE", updates.percentComplete);
     await request(task.href, {
       method: "PUT",
       headers: {
@@ -18557,7 +18664,7 @@ END:VCALENDAR`;
     const uid = crypto.randomUUID();
     const now = /* @__PURE__ */ new Date();
     const dtstamp = (0, import_date_fns.format)(now, "yyyyMMdd'T'HHmmss'Z'");
-    const toCalDavDate = (dateStr) => {
+    const toCalDavDate2 = (dateStr) => {
       const d = parseDateInput(dateStr);
       return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
     };
@@ -18568,8 +18675,8 @@ BEGIN:VEVENT
 UID:${uid}
 DTSTAMP:${dtstamp}
 SUMMARY:${escapePropertyValue(summary)}
-DTSTART:${toCalDavDate(start)}
-DTEND:${toCalDavDate(end)}
+DTSTART:${toCalDavDate2(start)}
+DTEND:${toCalDavDate2(end)}
 `;
     if (description) vevent += `DESCRIPTION:${escapePropertyValue(description)}
 `;
@@ -19550,7 +19657,24 @@ async function main() {
           "--description",
           "--description-file"
         ) ?? null;
-        output(await CalDAV.createTask(title, calendar, dueDate, priority, description));
+        const options = {
+          title,
+          calendar,
+          dueDate,
+          priority,
+          description
+        };
+        const startIndex = args.indexOf("--start");
+        if (startIndex !== -1) options.startDate = args[startIndex + 1];
+        const locIndex = args.indexOf("--location");
+        if (locIndex !== -1) options.location = args[locIndex + 1];
+        const urlIndex = args.indexOf("--url");
+        if (urlIndex !== -1) options.url = args[urlIndex + 1];
+        const classIndex = args.indexOf("--class");
+        if (classIndex !== -1) options.className = parseClassInput(args[classIndex + 1]);
+        const tagsIndex = args.indexOf("--tags");
+        if (tagsIndex !== -1) options.tags = parseTagsInput(args[tagsIndex + 1]);
+        output(await CalDAV.createTask(title, calendar, options));
       } else if (subCommand === "edit") {
         const uidIndex = args.indexOf("--uid");
         if (uidIndex === -1) throw new Error("Missing --uid");
@@ -19572,6 +19696,24 @@ async function main() {
           "--description-file"
         );
         if (description !== void 0) updates.description = description;
+        const startIndex = args.indexOf("--start");
+        if (startIndex !== -1) updates.startDate = args[startIndex + 1];
+        const locIndex = args.indexOf("--location");
+        if (locIndex !== -1) updates.location = args[locIndex + 1];
+        const urlIndex = args.indexOf("--url");
+        if (urlIndex !== -1) updates.url = args[urlIndex + 1];
+        const classIndex = args.indexOf("--class");
+        if (classIndex !== -1) updates.className = parseClassInput(args[classIndex + 1]);
+        const tagsIndex = args.indexOf("--tags");
+        if (tagsIndex !== -1) updates.tags = parseTagsInput(args[tagsIndex + 1]);
+        const statusIndex = args.indexOf("--status");
+        if (statusIndex !== -1) {
+          updates.status = parseStatusInput(args[statusIndex + 1]);
+        }
+        const percentIndex = args.indexOf("--percent-complete");
+        if (percentIndex !== -1) {
+          updates.percentComplete = parsePercentCompleteInput(args[percentIndex + 1]);
+        }
         output(await CalDAV.updateTask(uid, calendar, updates));
       } else if (subCommand === "delete") {
         const uidIndex = args.indexOf("--uid");

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -3614,15 +3614,15 @@ var require_protectedTokens = __commonJS({
     function isProtectedWeekYearToken(token) {
       return protectedWeekYearTokens.indexOf(token) !== -1;
     }
-    function throwProtectedError(token, format2, input) {
+    function throwProtectedError(token, format, input) {
       if (token === "YYYY") {
-        throw new RangeError("Use `yyyy` instead of `YYYY` (in `".concat(format2, "`) for formatting years to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
+        throw new RangeError("Use `yyyy` instead of `YYYY` (in `".concat(format, "`) for formatting years to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
       } else if (token === "YY") {
-        throw new RangeError("Use `yy` instead of `YY` (in `".concat(format2, "`) for formatting years to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
+        throw new RangeError("Use `yy` instead of `YY` (in `".concat(format, "`) for formatting years to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
       } else if (token === "D") {
-        throw new RangeError("Use `d` instead of `D` (in `".concat(format2, "`) for formatting days of the month to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
+        throw new RangeError("Use `d` instead of `D` (in `".concat(format, "`) for formatting days of the month to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
       } else if (token === "DD") {
-        throw new RangeError("Use `dd` instead of `DD` (in `".concat(format2, "`) for formatting days of the month to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
+        throw new RangeError("Use `dd` instead of `DD` (in `".concat(format, "`) for formatting days of the month to the input `").concat(input, "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md"));
       }
     }
   }
@@ -3736,8 +3736,8 @@ var require_buildFormatLongFn = __commonJS({
       return function() {
         var options = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
         var width = options.width ? String(options.width) : args.defaultWidth;
-        var format2 = args.formats[width] || args.formats[args.defaultWidth];
-        return format2;
+        var format = args.formats[width] || args.formats[args.defaultWidth];
+        return format;
       };
     }
     module.exports = exports2.default;
@@ -4241,7 +4241,7 @@ var require_format = __commonJS({
     Object.defineProperty(exports2, "__esModule", {
       value: true
     });
-    exports2.default = format2;
+    exports2.default = format;
     var _index = _interopRequireDefault(require_isValid());
     var _index2 = _interopRequireDefault(require_subMilliseconds());
     var _index3 = _interopRequireDefault(require_toDate());
@@ -4258,7 +4258,7 @@ var require_format = __commonJS({
     var escapedStringRegExp = /^'([^]*?)'?$/;
     var doubleQuoteRegExp = /''/g;
     var unescapedLatinCharacterRegExp = /[a-zA-Z]/;
-    function format2(dirtyDate, dirtyFormatStr, options) {
+    function format(dirtyDate, dirtyFormatStr, options) {
       var _ref, _options$locale, _ref2, _ref3, _ref4, _options$firstWeekCon, _options$locale2, _options$locale2$opti, _defaultOptions$local, _defaultOptions$local2, _ref5, _ref6, _ref7, _options$weekStartsOn, _options$locale3, _options$locale3$opti, _defaultOptions$local3, _defaultOptions$local4;
       (0, _index9.default)(2, arguments);
       var formatStr = String(dirtyFormatStr);
@@ -4646,13 +4646,13 @@ var require_formatDuration = __commonJS({
       }
       var defaultOptions3 = (0, _index.getDefaultOptions)();
       var locale = (_ref = (_options$locale = options === null || options === void 0 ? void 0 : options.locale) !== null && _options$locale !== void 0 ? _options$locale : defaultOptions3.locale) !== null && _ref !== void 0 ? _ref : _index2.default;
-      var format2 = (_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : defaultFormat;
+      var format = (_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : defaultFormat;
       var zero = (_options$zero = options === null || options === void 0 ? void 0 : options.zero) !== null && _options$zero !== void 0 ? _options$zero : false;
       var delimiter = (_options$delimiter = options === null || options === void 0 ? void 0 : options.delimiter) !== null && _options$delimiter !== void 0 ? _options$delimiter : " ";
       if (!locale.formatDistance) {
         return "";
       }
-      var result = format2.reduce(function(acc, unit) {
+      var result = format.reduce(function(acc, unit) {
         var token = "x".concat(unit.replace(/(^.)/, function(m) {
           return m.toUpperCase();
         }));
@@ -4687,9 +4687,9 @@ var require_formatISO = __commonJS({
       if (isNaN(originalDate.getTime())) {
         throw new RangeError("Invalid time value");
       }
-      var format2 = String((_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : "extended");
+      var format = String((_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : "extended");
       var representation = String((_options$representati = options === null || options === void 0 ? void 0 : options.representation) !== null && _options$representati !== void 0 ? _options$representati : "complete");
-      if (format2 !== "extended" && format2 !== "basic") {
+      if (format !== "extended" && format !== "basic") {
         throw new RangeError("format must be 'extended' or 'basic'");
       }
       if (representation !== "date" && representation !== "time" && representation !== "complete") {
@@ -4697,8 +4697,8 @@ var require_formatISO = __commonJS({
       }
       var result = "";
       var tzOffset = "";
-      var dateDelimiter = format2 === "extended" ? "-" : "";
-      var timeDelimiter = format2 === "extended" ? ":" : "";
+      var dateDelimiter = format === "extended" ? "-" : "";
+      var timeDelimiter = format === "extended" ? ":" : "";
       if (representation !== "time") {
         var day = (0, _index2.default)(originalDate.getDate(), 2);
         var month = (0, _index2.default)(originalDate.getMonth() + 1, 2);
@@ -4750,17 +4750,17 @@ var require_formatISO9075 = __commonJS({
       if (!(0, _index2.default)(originalDate)) {
         throw new RangeError("Invalid time value");
       }
-      var format2 = String((_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : "extended");
+      var format = String((_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : "extended");
       var representation = String((_options$representati = options === null || options === void 0 ? void 0 : options.representation) !== null && _options$representati !== void 0 ? _options$representati : "complete");
-      if (format2 !== "extended" && format2 !== "basic") {
+      if (format !== "extended" && format !== "basic") {
         throw new RangeError("format must be 'extended' or 'basic'");
       }
       if (representation !== "date" && representation !== "time" && representation !== "complete") {
         throw new RangeError("representation must be 'date', 'time', or 'complete'");
       }
       var result = "";
-      var dateDelimiter = format2 === "extended" ? "-" : "";
-      var timeDelimiter = format2 === "extended" ? ":" : "";
+      var dateDelimiter = format === "extended" ? "-" : "";
+      var timeDelimiter = format === "extended" ? ":" : "";
       if (representation !== "time") {
         var day = (0, _index3.default)(originalDate.getDate(), 2);
         var month = (0, _index3.default)(originalDate.getMonth() + 1, 2);
@@ -17904,6 +17904,13 @@ function parseClassInput(value) {
   }
   return normalized;
 }
+function parseUriInput(value) {
+  const uri = String(value).trim();
+  if (/[\u0000-\u001F\u007F]/.test(uri) || /\s/.test(uri)) {
+    throw new Error("URL must be a single URI with no spaces or line breaks.");
+  }
+  return uri;
+}
 function parseTagsInput(value) {
   if (typeof value !== "string" || value.trim() === "") {
     return [];
@@ -18024,8 +18031,40 @@ function parseDateInput(str) {
 function toCalDavDate(date) {
   return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
 }
-function validateTaskDates(startDate, dueDate) {
-  if (startDate && dueDate && startDate.getTime() > dueDate.getTime()) {
+function parseCalendarValue(str) {
+  const raw = String(str).trim();
+  const dateOnly = /^(\d{4})-?(\d{2})-?(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, y, mo, d] = dateOnly;
+    const date2 = /* @__PURE__ */ new Date(`${y}-${mo}-${d}T00:00:00Z`);
+    if (isNaN(date2.getTime())) {
+      throw new Error(`Invalid date '${str}'. Use ISO 8601 (2026-04-15) or CalDAV compact format (20260415).`);
+    }
+    return { date: date2, isDate: true, ical: `${y}${mo}${d}` };
+  }
+  const date = parseDateInput(raw);
+  return { date, isDate: false, ical: toCalDavDate(date) };
+}
+function readCalendarValue(text, prop) {
+  const match = text.match(new RegExp(`^${prop}(;[^:\r
+]*)?:(.*)$`, "m"));
+  if (!match) return null;
+  try {
+    const value = parseCalendarValue(match[2].trim());
+    const declaredDate = /(?:^|;)VALUE=DATE(?:;|$)/i.test(match[1] || "");
+    return declaredDate ? { ...value, isDate: true } : value;
+  } catch {
+    return null;
+  }
+}
+function validateTaskDates(start, due) {
+  if (!start || !due) return;
+  if (start.isDate !== due.isDate) {
+    throw new Error(
+      "A task's start and due dates must both be all-day dates (2026-04-15) or both carry a time (2026-04-15T17:00:00Z). Set --start and --due together to change which form the task uses."
+    );
+  }
+  if (start.date.getTime() > due.date.getTime()) {
     throw new Error("Start date must be earlier than or equal to due date.");
   }
 }
@@ -18300,12 +18339,8 @@ var CalDAV = {
   async getEvents(start, end) {
     const calendars = await this.findCalendars("VEVENT");
     const allEvents = [];
-    const toCalDavDate2 = (dateStr) => {
-      const d = parseDateInput(dateStr);
-      return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
-    };
-    const startStr = toCalDavDate2(start);
-    const endStr = toCalDavDate2(end);
+    const startStr = toCalDavDate(parseDateInput(start));
+    const endStr = toCalDavDate(parseDateInput(end));
     const body = `
             <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
                 <d:prop>
@@ -18396,18 +18431,19 @@ var CalDAV = {
             continue;
           }
           const calData = propstats[0]["d:prop"]["cal:calendar-data"];
-          const unfolded = calData.replace(/\r?\n[ \t]/g, "");
-          const summaryMatch = calData.match(/SUMMARY:(.*)/);
-          const descriptionMatch = unfolded.match(/^DESCRIPTION(?:;[^:]*)?:(.*)$/m);
-          const statusMatch = unfolded.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
-          const uidMatch = calData.match(/UID:(.*)/);
-          const startMatch = calData.match(/DTSTART(?:;.*)?:(.*)/);
-          const dueMatch = calData.match(/DUE(?:;.*)?:(.*)/);
-          const priorityMatch = calData.match(/PRIORITY:(.*)/);
-          const locationMatch = unfolded.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
-          const urlMatch = unfolded.match(/^URL(?:;[^:]*)?:(.*)$/m);
-          const classMatch = unfolded.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
-          const categoriesMatch = unfolded.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
+          const vtodo = this._componentText(calData);
+          if (!vtodo) continue;
+          const summaryMatch = vtodo.match(/^SUMMARY(?:;[^:]*)?:(.*)$/m);
+          const descriptionMatch = vtodo.match(/^DESCRIPTION(?:;[^:]*)?:(.*)$/m);
+          const statusMatch = vtodo.match(/^STATUS(?:;[^:]*)?:(.*)$/m);
+          const uidMatch = vtodo.match(/^UID(?:;[^:]*)?:(.*)$/m);
+          const startMatch = vtodo.match(/^DTSTART(?:;[^:]*)?:(.*)$/m);
+          const dueMatch = vtodo.match(/^DUE(?:;[^:]*)?:(.*)$/m);
+          const priorityMatch = vtodo.match(/^PRIORITY(?:;[^:]*)?:(.*)$/m);
+          const locationMatch = vtodo.match(/^LOCATION(?:;[^:]*)?:(.*)$/m);
+          const urlMatch = vtodo.match(/^URL(?:;[^:]*)?:(.*)$/m);
+          const classMatch = vtodo.match(/^CLASS(?:;[^:]*)?:(.*)$/m);
+          const categoriesMatch = vtodo.match(/^CATEGORIES(?:;[^:]*)?:(.*)$/m);
           const status = statusMatch ? statusMatch[1].trim() : "NEEDS-ACTION";
           if (status === "COMPLETED") continue;
           let tags = null;
@@ -18518,25 +18554,62 @@ var CalDAV = {
     }
     return null;
   },
-  _updateProperty(vcal, prop, value) {
-    if (value === null || value === void 0) {
-      return vcal;
+  // Index the lines belonging to the VTODO or VEVENT itself. Properties must
+  // never be read from or written to anything else in the VCALENDAR: a
+  // VTIMEZONE carries DTSTART lines of its own (the DST rules, dated 1970),
+  // and a VALARM carries its own SUMMARY and DESCRIPTION. An unscoped match
+  // finds whichever comes first in the file.
+  _componentLines(lines) {
+    let name = null;
+    let nested = 0;
+    const own = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!name) {
+        const begin = /^BEGIN:(VTODO|VEVENT)\s*$/.exec(line);
+        if (begin) name = begin[1];
+        continue;
+      }
+      if (nested === 0 && new RegExp(`^END:${name}\\s*$`).test(line)) {
+        return { name, own, end: i };
+      }
+      if (/^BEGIN:/.test(line)) nested++;
+      else if (/^END:/.test(line)) nested--;
+      else if (nested === 0) own.push(i);
     }
-    const regex = new RegExp(`^${prop}(?:;[^:\\r\\n]*)?:.*$`, "m");
-    const newLine = `${prop}:${value}`;
-    if (regex.test(vcal)) {
-      return vcal.replace(regex, () => newLine);
-    }
-    const endMatch = vcal.match(/END:(VTODO|VEVENT)/);
-    if (!endMatch) {
+    return null;
+  },
+  // The component's own property lines, unfolded, for reading values out of.
+  _componentText(vcal) {
+    const lines = vcal.replace(/\r?\n[ \t]/g, "").split(/\r?\n/);
+    const component = this._componentLines(lines);
+    return component ? component.own.map((i) => lines[i]).join("\n") : "";
+  },
+  // Replace, insert, or (value === null) remove a property on the component.
+  _updateProperty(vcal, prop, value, params = null) {
+    if (value === void 0) return vcal;
+    const lines = vcal.split(/\r?\n/);
+    const component = this._componentLines(lines);
+    if (!component) {
       throw new Error("Cannot insert property: no END:VTODO or END:VEVENT found in calendar data.");
     }
-    return vcal.replace(endMatch[0], () => `${newLine}
-${endMatch[0]}`);
+    const eol = vcal.includes("\r\n") ? "\r\n" : "\n";
+    const newLine = value === null ? null : `${prop}${params ? `;${params}` : ""}:${value}`;
+    const regex = new RegExp(`^${prop}(?:;[^:]*)?:`);
+    const first = component.own.find((i) => regex.test(lines[i]));
+    if (first === void 0) {
+      if (newLine === null) return vcal;
+      lines.splice(component.end, 0, newLine);
+      return lines.join(eol);
+    }
+    let last = first;
+    while (last + 1 < lines.length && /^[ \t]/.test(lines[last + 1])) last++;
+    lines.splice(first, last - first + 1, ...newLine === null ? [] : [newLine]);
+    return lines.join(eol);
   },
   async createTask(title, calendarName, options = {}) {
-    const start = options.startDate ? parseDateInput(options.startDate) : null;
-    const due = options.dueDate ? parseDateInput(options.dueDate) : null;
+    const start = options.startDate ? parseCalendarValue(options.startDate) : null;
+    const due = options.dueDate ? parseCalendarValue(options.dueDate) : null;
     validateTaskDates(start, due);
     const cal = await this.getCalendar(calendarName, "VTODO");
     const uid = crypto.randomUUID();
@@ -18551,9 +18624,9 @@ DTSTAMP:${dtstamp}
 SUMMARY:${escapePropertyValue(title)}
 STATUS:NEEDS-ACTION
 `;
-    if (start) vtodo += `DTSTART:${toCalDavDate(start)}
+    if (start) vtodo += `DTSTART${start.isDate ? ";VALUE=DATE" : ""}:${start.ical}
 `;
-    if (due) vtodo += `DUE:${toCalDavDate(due)}
+    if (due) vtodo += `DUE${due.isDate ? ";VALUE=DATE" : ""}:${due.ical}
 `;
     if (options.priority) vtodo += `PRIORITY:${options.priority}
 `;
@@ -18561,7 +18634,7 @@ STATUS:NEEDS-ACTION
 `;
     if (options.location) vtodo += `LOCATION:${escapePropertyValue(options.location)}
 `;
-    if (options.url) vtodo += `URL:${escapePropertyValue(options.url)}
+    if (options.url) vtodo += `URL:${options.url}
 `;
     if (options.className) vtodo += `CLASS:${options.className}
 `;
@@ -18592,31 +18665,31 @@ END:VCALENDAR`;
     if (updates.priority) vtodo = this._updateProperty(vtodo, "PRIORITY", updates.priority);
     if (updates.description) vtodo = this._updateProperty(vtodo, "DESCRIPTION", escapePropertyValue(updates.description));
     if (updates.startDate || updates.dueDate) {
-      const start = updates.startDate ? parseDateInput(updates.startDate) : null;
-      const due = updates.dueDate ? parseDateInput(updates.dueDate) : null;
-      const existingStartMatch = vtodo.match(/DTSTART(?:;.*)?:(.*)/);
-      const existingDueMatch = vtodo.match(/DUE(?:;.*)?:(.*)/);
-      const existingStart = existingStartMatch ? parseDateInput(existingStartMatch[1].trim()) : null;
-      const existingDue = existingDueMatch ? parseDateInput(existingDueMatch[1].trim()) : null;
-      validateTaskDates(start || existingStart, due || existingDue);
-      if (start) vtodo = this._updateProperty(vtodo, "DTSTART", toCalDavDate(start));
-      if (due) vtodo = this._updateProperty(vtodo, "DUE", toCalDavDate(due));
+      const start = updates.startDate ? parseCalendarValue(updates.startDate) : null;
+      const due = updates.dueDate ? parseCalendarValue(updates.dueDate) : null;
+      const stored = this._componentText(vtodo);
+      validateTaskDates(
+        start || readCalendarValue(stored, "DTSTART"),
+        due || readCalendarValue(stored, "DUE")
+      );
+      if (start) vtodo = this._updateProperty(vtodo, "DTSTART", start.ical, start.isDate ? "VALUE=DATE" : null);
+      if (due) vtodo = this._updateProperty(vtodo, "DUE", due.ical, due.isDate ? "VALUE=DATE" : null);
     }
     if (updates.location !== void 0) {
       vtodo = this._updateProperty(vtodo, "LOCATION", updates.location === null ? null : escapePropertyValue(updates.location));
     }
     if (updates.url !== void 0) {
-      vtodo = this._updateProperty(vtodo, "URL", updates.url === null ? null : escapePropertyValue(updates.url));
+      vtodo = this._updateProperty(vtodo, "URL", updates.url);
     }
     if (updates.className !== void 0) {
       vtodo = this._updateProperty(vtodo, "CLASS", updates.className);
     }
     if (updates.tags !== void 0) {
-      if (updates.tags === null || updates.tags.length === 0) {
-        vtodo = this._updateProperty(vtodo, "CATEGORIES", null);
-      } else {
-        vtodo = this._updateProperty(vtodo, "CATEGORIES", updates.tags.map(escapePropertyValue).join(","));
-      }
+      vtodo = this._updateProperty(
+        vtodo,
+        "CATEGORIES",
+        updates.tags === null || updates.tags.length === 0 ? null : updates.tags.map(escapePropertyValue).join(",")
+      );
     }
     if (updates.status) vtodo = this._updateProperty(vtodo, "STATUS", updates.status);
     if (updates.percentComplete !== void 0) vtodo = this._updateProperty(vtodo, "PERCENT-COMPLETE", updates.percentComplete);
@@ -18643,7 +18716,7 @@ END:VCALENDAR`;
     if (!task) throw new Error(`Task ${uid} not found.`);
     let vtodo = task.data;
     const now = /* @__PURE__ */ new Date();
-    const completedDate = (0, import_date_fns.format)(now, "yyyyMMdd'T'HHmmss'Z'");
+    const completedDate = toCalDavDate(now);
     vtodo = this._updateProperty(vtodo, "STATUS", "COMPLETED");
     vtodo = this._updateProperty(vtodo, "COMPLETED", completedDate);
     vtodo = this._updateProperty(vtodo, "PERCENT-COMPLETE", "100");
@@ -18663,11 +18736,7 @@ END:VCALENDAR`;
     const cal = await this.getCalendar(calendarName, "VEVENT");
     const uid = crypto.randomUUID();
     const now = /* @__PURE__ */ new Date();
-    const dtstamp = (0, import_date_fns.format)(now, "yyyyMMdd'T'HHmmss'Z'");
-    const toCalDavDate2 = (dateStr) => {
-      const d = parseDateInput(dateStr);
-      return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
-    };
+    const dtstamp = toCalDavDate(now);
     let vevent = `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//OpenClaw//Nextcloud Skill//EN
@@ -18675,8 +18744,8 @@ BEGIN:VEVENT
 UID:${uid}
 DTSTAMP:${dtstamp}
 SUMMARY:${escapePropertyValue(summary)}
-DTSTART:${toCalDavDate2(start)}
-DTEND:${toCalDavDate2(end)}
+DTSTART:${toCalDavDate(parseDateInput(start))}
+DTEND:${toCalDavDate(parseDateInput(end))}
 `;
     if (description) vevent += `DESCRIPTION:${escapePropertyValue(description)}
 `;
@@ -18764,11 +18833,11 @@ END:VCALENDAR`;
     if (updates.summary) vevent = this._updateProperty(vevent, "SUMMARY", escapePropertyValue(updates.summary));
     if (updates.start) {
       const d = parseDateInput(updates.start);
-      vevent = this._updateProperty(vevent, "DTSTART", d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z");
+      vevent = this._updateProperty(vevent, "DTSTART", toCalDavDate(d));
     }
     if (updates.end) {
       const d = parseDateInput(updates.end);
-      vevent = this._updateProperty(vevent, "DTEND", d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z");
+      vevent = this._updateProperty(vevent, "DTEND", toCalDavDate(d));
     }
     if (updates.description !== void 0) {
       vevent = this._updateProperty(vevent, "DESCRIPTION", escapePropertyValue(updates.description));
@@ -19664,16 +19733,16 @@ async function main() {
           priority,
           description
         };
-        const startIndex = args.indexOf("--start");
-        if (startIndex !== -1) options.startDate = args[startIndex + 1];
-        const locIndex = args.indexOf("--location");
-        if (locIndex !== -1) options.location = args[locIndex + 1];
-        const urlIndex = args.indexOf("--url");
-        if (urlIndex !== -1) options.url = args[urlIndex + 1];
-        const classIndex = args.indexOf("--class");
-        if (classIndex !== -1) options.className = parseClassInput(args[classIndex + 1]);
-        const tagsIndex = args.indexOf("--tags");
-        if (tagsIndex !== -1) options.tags = parseTagsInput(args[tagsIndex + 1]);
+        const start = getOptionValue(args, "--start");
+        if (start) options.startDate = start;
+        const location = getOptionValue(args, "--location");
+        if (location) options.location = location;
+        const url = getOptionValue(args, "--url");
+        if (url) options.url = parseUriInput(url);
+        const className = getOptionValue(args, "--class");
+        if (className) options.className = parseClassInput(className);
+        const tags = getOptionValue(args, "--tags");
+        if (tags) options.tags = parseTagsInput(tags);
         output(await CalDAV.createTask(title, calendar, options));
       } else if (subCommand === "edit") {
         const uidIndex = args.indexOf("--uid");
@@ -19696,16 +19765,16 @@ async function main() {
           "--description-file"
         );
         if (description !== void 0) updates.description = description;
-        const startIndex = args.indexOf("--start");
-        if (startIndex !== -1) updates.startDate = args[startIndex + 1];
-        const locIndex = args.indexOf("--location");
-        if (locIndex !== -1) updates.location = args[locIndex + 1];
-        const urlIndex = args.indexOf("--url");
-        if (urlIndex !== -1) updates.url = args[urlIndex + 1];
-        const classIndex = args.indexOf("--class");
-        if (classIndex !== -1) updates.className = parseClassInput(args[classIndex + 1]);
-        const tagsIndex = args.indexOf("--tags");
-        if (tagsIndex !== -1) updates.tags = parseTagsInput(args[tagsIndex + 1]);
+        const start = getOptionValue(args, "--start");
+        if (start) updates.startDate = start;
+        const location = getOptionValue(args, "--location");
+        if (location !== void 0) updates.location = location === "" ? null : location;
+        const url = getOptionValue(args, "--url");
+        if (url !== void 0) updates.url = url === "" ? null : parseUriInput(url);
+        const className = getOptionValue(args, "--class");
+        if (className !== void 0) updates.className = className === "" ? null : parseClassInput(className);
+        const tags = getOptionValue(args, "--tags");
+        if (tags !== void 0) updates.tags = parseTagsInput(tags);
         const statusIndex = args.indexOf("--status");
         if (statusIndex !== -1) {
           updates.status = parseStatusInput(args[statusIndex + 1]);

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -82,6 +82,7 @@ UID:task-1
 SUMMARY:Call Alice\\, Bob
 DESCRIPTION:First line\\nSecond line
 STATUS:NEEDS-ACTION
+DUE:20260730T120000Z
 PRIORITY:5
 END:VTODO
 END:VCALENDAR</cal:calendar-data>
@@ -506,6 +507,141 @@ for (const [subcommand, args] of [
       requests.length === before,
     { result }
   );
+}
+
+// New task metadata options: status and percent-complete.
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-1',
+  '--status', 'IN-PROCESS',
+  '--percent-complete', '42'
+]);
+const metadataPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'tasks edit writes STATUS and PERCENT-COMPLETE',
+  result.code === 0 &&
+    metadataPut?.body.includes('STATUS:IN-PROCESS') &&
+    metadataPut?.body.includes('PERCENT-COMPLETE:42'),
+  { body: metadataPut?.body ?? null, result }
+);
+
+for (const [flag, value, expectedMsg] of [
+  ['--status', 'INVALID', "Invalid status 'INVALID'"],
+  ['--percent-complete', '101', 'Percent-complete must be between 0 and 100'],
+  ['--percent-complete', 'abc', 'Percent-complete must be an integer']
+]) {
+  before = requests.length;
+  result = await run(['tasks', 'edit', '--uid', 'task-1', flag, value]);
+  record(
+    `tasks edit rejects ${flag}=${value} before a request`,
+    result.code !== 0 &&
+      result.stderr.includes(expectedMsg) &&
+      requests.length === before,
+    { result }
+  );
+}
+
+// Extended task metadata: start, location, url, class, tags.
+before = requests.length;
+result = await run([
+  'tasks', 'create',
+  '--title', 'Full metadata task',
+  '--start', '2026-09-01T10:00:00Z',
+  '--due', '2026-09-02T10:00:00Z',
+  '--priority', '5',
+  '--location', 'Home office',
+  '--url', 'https://example.com',
+  '--class', 'PRIVATE',
+  '--tags', 'work,urgent'
+]);
+const createMetadataPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'tasks create writes start, location, url, class, and tags',
+  result.code === 0 &&
+    createMetadataPut?.body.includes('DTSTART:20260901') &&
+    createMetadataPut?.body.includes('DUE:20260902') &&
+    createMetadataPut?.body.includes('PRIORITY:5') &&
+    createMetadataPut?.body.includes('LOCATION:Home office') &&
+    createMetadataPut?.body.includes('URL:https://example.com') &&
+    createMetadataPut?.body.includes('CLASS:PRIVATE') &&
+    createMetadataPut?.body.includes('CATEGORIES:work,urgent'),
+  { body: createMetadataPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-1',
+  '--start', '2026-07-01T10:00:00Z',
+  '--location', 'Updated office',
+  '--url', 'https://updated.example.com',
+  '--class', 'CONFIDENTIAL',
+  '--tags', 'review,later'
+]);
+const editMetadataPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'tasks edit writes start, location, url, class, and tags',
+  result.code === 0 &&
+    editMetadataPut?.body.includes('DTSTART:20260701') &&
+    editMetadataPut?.body.includes('LOCATION:Updated office') &&
+    editMetadataPut?.body.includes('URL:https://updated.example.com') &&
+    editMetadataPut?.body.includes('CLASS:CONFIDENTIAL') &&
+    editMetadataPut?.body.includes('CATEGORIES:review,later'),
+  { body: editMetadataPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run([
+  'tasks', 'create',
+  '--title', 'Inverted dates',
+  '--start', '2026-09-02T10:00:00Z',
+  '--due', '2026-09-01T10:00:00Z'
+]);
+record(
+  'tasks create rejects start date after due date before a request',
+  result.code !== 0 &&
+    result.stderr.includes('Start date must be earlier than or equal to due date') &&
+    requests.length === before,
+  { result }
+);
+
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-1',
+  '--start', '2099-01-01T00:00:00Z'
+]);
+const editValidationPuts = requests.slice(before).filter(entry => entry.method === 'PUT');
+record(
+  'tasks edit rejects start date after existing due date before a PUT',
+  result.code !== 0 &&
+    result.stderr.includes('Start date must be earlier than or equal to due date') &&
+    editValidationPuts.length === 0,
+  { result }
+);
+
+for (const [flag, value, expectedMsg] of [
+  ['--class', 'SECRET', "Invalid class 'SECRET'"],
+  ['--class', 'public', ''] // valid, lowercase should normalize
+]) {
+  before = requests.length;
+  result = await run(['tasks', 'edit', '--uid', 'task-1', flag, value]);
+  if (expectedMsg === '') {
+    record(
+      'tasks edit accepts lowercase class values',
+      result.code === 0,
+      { result }
+    );
+  } else {
+    record(
+      `tasks edit rejects ${flag}=${value} before a request`,
+      result.code !== 0 &&
+        result.stderr.includes(expectedMsg) &&
+        requests.length === before,
+      { result }
+    );
+  }
 }
 } finally {
   await new Promise(resolveClose => server.close(resolveClose));

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -143,6 +143,96 @@ END:VCALENDAR</cal:calendar-data>
   </d:response>
 </d:multistatus>`;
 
+// A task as the Nextcloud Tasks web UI stores it: local times pinned by a
+// VTIMEZONE whose DST rules carry DTSTART lines of their own, and a VALARM with
+// its own SUMMARY and DESCRIPTION, both ahead of the task's.
+const timezoneTodo = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Nextcloud Tasks v0.18.1
+BEGIN:VTIMEZONE
+TZID:Europe/Malta
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VTODO
+UID:task-timezone
+BEGIN:VALARM
+ACTION:DISPLAY
+SUMMARY:Alarm summary
+DESCRIPTION:Alarm description
+TRIGGER:-PT15M
+END:VALARM
+SUMMARY:Timezoned task
+STATUS:NEEDS-ACTION
+DTSTART;TZID=Europe/Malta:20260901T090000
+DUE;TZID=Europe/Malta:20260930T170000
+END:VTODO
+END:VCALENDAR`;
+
+// An all-day task: DUE is a DATE, so a DTSTART beside it has to be one too.
+const allDayTodo = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-allday
+SUMMARY:All-day task
+STATUS:NEEDS-ACTION
+DUE;VALUE=DATE:20260828
+END:VTODO
+END:VCALENDAR`;
+
+// Metadata to clear, including a URL folded across two lines the way a server
+// returns one longer than 75 octets.
+const metadataTodo = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-metadata
+SUMMARY:Task with metadata
+STATUS:NEEDS-ACTION
+LOCATION:Old office
+URL:https://example.com/a/very/long/path/that/a/server/would/fold/across/two/
+ lines?query=1
+CATEGORIES:work,urgent
+END:VTODO
+END:VCALENDAR`;
+
+function todoResponse(name, calendarData) {
+  return `  <d:response>
+    <d:href>/remote.php/dav/calendars/tester/personal/${name}.ics</d:href>
+    <d:propstat><d:prop>
+      <d:getetag>"${name}"</d:getetag>
+      <cal:calendar-data>${calendarData}</cal:calendar-data>
+    </d:prop></d:propstat>
+  </d:response>
+`;
+}
+
+function todoMultistatus(body) {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+${body}</d:multistatus>`;
+}
+
+const timezoneTodoReport = todoMultistatus(todoResponse('timezone', timezoneTodo));
+const allDayTodoReport = todoMultistatus(todoResponse('allday', allDayTodo));
+const metadataTodoReport = todoMultistatus(todoResponse('metadata', metadataTodo));
+
+// The timezoned task is in the list report too, so `tasks list` is exercised
+// against a VCALENDAR that carries DTSTART lines outside the VTODO.
+const todoListReport = todoReport.replace(
+  '</d:multistatus>',
+  `${todoResponse('timezone', timezoneTodo)}</d:multistatus>`
+);
+
 const server = http.createServer(async (req, res) => {
   let body = '';
   for await (const chunk of req) body += chunk;
@@ -164,7 +254,13 @@ const server = http.createServer(async (req, res) => {
   } else if (req.method === 'REPORT' &&
              req.url === '/remote.php/dav/calendars/tester/personal/') {
     res.setHeader('content-type', 'application/xml');
-    res.end(body.includes('VTODO') ? todoReport : eventReport);
+    // findTaskPath names the UID it is looking for in the query, so a fixture can
+    // be aimed at one test without changing what `tasks list` sees.
+    if (!body.includes('VTODO')) res.end(eventReport);
+    else if (body.includes('task-timezone')) res.end(timezoneTodoReport);
+    else if (body.includes('task-allday')) res.end(allDayTodoReport);
+    else if (body.includes('task-metadata')) res.end(metadataTodoReport);
+    else res.end(todoListReport);
   } else {
     res.setHeader('content-type', 'text/plain');
     res.end('ok');
@@ -643,6 +739,159 @@ for (const [flag, value, expectedMsg] of [
     );
   }
 }
+// --- Properties are read from and written to the VTODO, not the VCALENDAR ---
+
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-timezone',
+  '--start', '2026-09-02T10:00:00Z'
+]);
+const timezonePut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'editing a start leaves the VTIMEZONE DST rules alone',
+  result.code === 0 &&
+    /BEGIN:VTODO[\s\S]*DTSTART:20260902T100000Z[\s\S]*END:VTODO/.test(timezonePut?.body ?? '') &&
+    timezonePut?.body.includes('DTSTART:19700329T020000') &&
+    timezonePut?.body.includes('DTSTART:19701025T030000') &&
+    !timezonePut?.body.includes('DTSTART;TZID=Europe/Malta:20260901T090000'),
+  { body: timezonePut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run(['tasks', 'edit', '--uid', 'task-timezone', '--title', 'Renamed']);
+const alarmPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'editing a title leaves a VALARM subcomponent alone',
+  result.code === 0 &&
+    alarmPut?.body.includes('SUMMARY:Renamed') &&
+    alarmPut?.body.includes('SUMMARY:Alarm summary') &&
+    !alarmPut?.body.includes('SUMMARY:Timezoned task'),
+  { body: alarmPut?.body ?? null, result }
+);
+
+result = await run(['tasks', 'list', '--calendar', 'Personal']);
+let timezoneTask = null;
+try {
+  timezoneTask = (JSON.parse(result.stdout)?.data ?? [])
+    .find(task => task.uid === 'task-timezone') ?? null;
+} catch {
+  // The assertion below preserves the parse failure as test evidence.
+}
+record(
+  'tasks list reports the task start, not a VTIMEZONE DST rule',
+  result.code === 0 && timezoneTask?.start === '20260901T090000',
+  { timezoneTask, result }
+);
+
+// --- All-day tasks keep the DATE value type on both ends ---
+
+before = requests.length;
+result = await run(['tasks', 'edit', '--uid', 'task-allday', '--start', '2026-08-27']);
+const allDayPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'a start added to an all-day task is written as a DATE',
+  result.code === 0 &&
+    allDayPut?.body.includes('DTSTART;VALUE=DATE:20260827') &&
+    allDayPut?.body.includes('DUE;VALUE=DATE:20260828'),
+  { body: allDayPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run(['tasks', 'edit', '--uid', 'task-allday', '--start', '2026-08-28T09:00:00Z']);
+record(
+  'a timed start on an all-day task is refused rather than written',
+  result.code !== 0 &&
+    result.stderr.includes('must both be all-day dates') &&
+    requests.slice(before).filter(entry => entry.method === 'PUT').length === 0,
+  { result }
+);
+
+before = requests.length;
+result = await run(['tasks', 'create', '--title', 'All-day', '--due', '2026-09-02']);
+const allDayCreatePut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'a due date with no time creates an all-day task',
+  result.code === 0 && allDayCreatePut?.body.includes('DUE;VALUE=DATE:20260902'),
+  { body: allDayCreatePut?.body ?? null, result }
+);
+
+// --- Clearing metadata, and replacing a folded value ---
+
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-metadata',
+  '--location', '',
+  '--url', '',
+  '--tags', ''
+]);
+const clearPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'an empty value removes the property from the task',
+  result.code === 0 &&
+    !/^LOCATION[;:]/m.test(clearPut?.body ?? '') &&
+    !/^URL[;:]/m.test(clearPut?.body ?? '') &&
+    !/^CATEGORIES[;:]/m.test(clearPut?.body ?? '') &&
+    !clearPut?.body.includes('lines?query=1'),
+  { body: clearPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run([
+  'tasks', 'edit',
+  '--uid', 'task-metadata',
+  '--url', 'https://example.com/short'
+]);
+const refoldPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'replacing a folded value takes its continuation lines with it',
+  result.code === 0 &&
+    refoldPut?.body.includes('URL:https://example.com/short') &&
+    !refoldPut?.body.includes('lines?query=1'),
+  { body: refoldPut?.body ?? null, result }
+);
+
+// --- URL is a URI, not escaped text ---
+
+before = requests.length;
+result = await run([
+  'tasks', 'create',
+  '--title', 'Linked task',
+  '--url', 'https://example.com/search?a=1,b=2'
+]);
+const uriPut = requests.slice(before).find(entry => entry.method === 'PUT');
+record(
+  'a comma in a URL is written literally, not backslash-escaped',
+  result.code === 0 &&
+    uriPut?.body.includes('URL:https://example.com/search?a=1,b=2'),
+  { body: uriPut?.body ?? null, result }
+);
+
+before = requests.length;
+result = await run(['tasks', 'create', '--title', 'Bad link', '--url', 'not a uri']);
+record(
+  'a URL containing spaces is rejected before a request',
+  result.code !== 0 &&
+    result.stderr.includes('URL must be a single URI') &&
+    requests.length === before,
+  { result }
+);
+
+// --- Timestamps we generate are UTC ---
+
+before = requests.length;
+result = await run(['tasks', 'complete', '--uid', 'task-1']);
+const completePut = requests.slice(before).find(entry => entry.method === 'PUT');
+const completedStamp = (completePut?.body ?? '').match(/^COMPLETED:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/m);
+const completedAt = completedStamp
+  ? Date.parse(`${completedStamp[1]}-${completedStamp[2]}-${completedStamp[3]}T${completedStamp[4]}:${completedStamp[5]}:${completedStamp[6]}Z`)
+  : NaN;
+record(
+  'COMPLETED is stamped in UTC, as its Z suffix claims',
+  result.code === 0 && Math.abs(Date.now() - completedAt) < 5 * 60 * 1000,
+  { body: completePut?.body ?? null, result }
+);
 } finally {
   await new Promise(resolveClose => server.close(resolveClose));
 }


### PR DESCRIPTION
## Summary

This PR extends the `tasks create` and `tasks edit` commands with the optional metadata fields exposed by the Nextcloud Tasks web UI:

- `--start` → `DTSTART` (start date)
- `--location` → `LOCATION`
- `--url` → `URL`
- `--class` → `CLASS` (`PUBLIC` / `PRIVATE` / `CONFIDENTIAL`)
- `--tags` → `CATEGORIES` (comma-separated)
- `--status` → `STATUS` (edit only)
- `--percent-complete` → `PERCENT-COMPLETE` (edit only)

`tasks list` now returns the new fields, and input validation is performed before any CalDAV request is sent.

Also fixes a UTC date-formatting bug where DUE/DTSTART were written in the machine's local timezone while still carrying a `Z` suffix, and adds a check that prevents start dates from being later than due dates.

## Testing

- `npm test`: 64/64 tests pass.
- Regression tests added for all new flags and validations.
- Live local test against Nextcloud confirmed create, edit, list, and validation behavior.

## Testing Environment

- Linux Mint Debian Edition (LMDE) 7
- OpenClaw gateway 2026.7.1-2
- Nextcloud server 34.0.3
- Nextcloud Tasks version 0.18.1
- openclaw-nextcloud skill version 0.4.2

## Notice

This pull request was submitted by an automated software agent (@kens-agents) who works for @kendawson-online. The feature was suggested by Ken Dawson (@kendawson-online), who operates the OpenClaw gateway that consumes this skill. To reach the agent: bert@kendawson.cloud. To reach the reporting human for environment/feature questions: ken@kendawson.online.
