### PR TITLE
fix(cli): correct usage string to scripts/nextcloud.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2823,7 +2823,7 @@ async function main() {
                 throw new Error('Unknown labels command');
             }
         } else {
-            console.log('Usage: node index.js <notes|files|calendar|calendars|tasks|contacts|addressbooks|shares|boards|stacks|cards|labels> <list|get|create|search|edit|delete|move|create-link> [options]');
+            console.log('Usage: node scripts/nextcloud.js <notes|files|calendar|calendars|tasks|contacts|addressbooks|shares|boards|stacks|cards|labels> <list|get|create|search|edit|delete|move|create-link> [options]');
         }
     } catch (err) {
         errorOutput(err);

--- a/scripts/nextcloud.js
+++ b/scripts/nextcloud.js
@@ -20102,7 +20102,7 @@ async function main() {
         throw new Error("Unknown labels command");
       }
     } else {
-      console.log("Usage: node index.js <notes|files|calendar|calendars|tasks|contacts|addressbooks|shares|boards|stacks|cards|labels> <list|get|create|search|edit|delete|move|create-link> [options]");
+      console.log("Usage: node scripts/nextcloud.js <notes|files|calendar|calendars|tasks|contacts|addressbooks|shares|boards|stacks|cards|labels> <list|get|create|search|edit|delete|move|create-link> [options]");
     }
   } catch (err) {
     errorOutput(err);


### PR DESCRIPTION
The no-command usage hint hardcoded `node index.js`, but the actual entry point (package.json bin + all 53 README examples) is `node scripts/nextcloud.js`. Running the CLI with no args printed a usage hint pointing at a file that is not how the tool is invoked.

Rebuilt the bundle with the pinned esbuild (0.28.1) so the diff is exactly the one string change, 0 noise lines. CI verify-bundle-matches-source should pass.